### PR TITLE
xen/evtchn: Add register-based EVTCHNOP_send

### DIFF
--- a/.github/workflows/microv.yml
+++ b/.github/workflows/microv.yml
@@ -61,6 +61,7 @@ jobs:
         echo 'set(ENABLE_BUILD_USERSPACE OFF)' >> ../config.cmake
         echo 'set(ENABLE_BUILD_VMM ON)' >> ../config.cmake
         echo 'set(ENABLE_BUILD_EFI ON)' >> ../config.cmake
+        echo 'set(XEN_REGISTER_SEND ON)' >> ../config.cmake
         cmake ../microv/deps/hypervisor -DCONFIG=../config.cmake -DCMAKE_CXX_FLAGS="--verbose "
         make
       shell: bash
@@ -130,7 +131,7 @@ jobs:
     - name: Build Drivers
       run: |
         cd .\microv\drivers
-        .\build-all.ps1
+        .\build-all.ps1 -RegisterSend
       shell: pwsh
 
     - uses: actions/upload-artifact@v2

--- a/deps/hypervisor/scripts/cmake/CMakeLists.txt
+++ b/deps/hypervisor/scripts/cmake/CMakeLists.txt
@@ -130,6 +130,7 @@ target_compile_definitions(bfroot INTERFACE
     $<${VMM_C_CXX}:__SINGLE_THREAD__>
     $<${VMM_C_CXX}:__ELF__>
     $<$<BOOL:${USE_XUE}>:USE_XUE>
+    $<$<BOOL:${XEN_REGISTER_SEND}>:XEN_REGISTER_SEND>
 )
 target_include_directories(bfroot SYSTEM INTERFACE
     $<INSTALL_INTERFACE:$<${VMM_C_CXX}:${VMM_PREFIX_PATH}/include/c++/v1>>

--- a/drivers/build-all.ps1
+++ b/drivers/build-all.ps1
@@ -20,7 +20,8 @@
 # SOFTWARE.
 
 param(
-    [switch] $Debug
+    [switch] $Debug,
+    [switch] $RegisterSend
 )
 
 $dir_list = Get-ChildItem $dir -Directory | Select-Object Name
@@ -45,5 +46,9 @@ pushd visr\windows
 popd
 
 pushd winpv
-.\clean-build.ps1 $Debug
+if ($RegisterSend) {
+    .\clean-build.ps1 $Debug -RegisterSend
+} else {
+    .\clean-build.ps1 $Debug
+}
 popd

--- a/drivers/winpv/clean-build.ps1
+++ b/drivers/winpv/clean-build.ps1
@@ -20,7 +20,8 @@
 # SOFTWARE.
 
 param(
-    [switch] $Debug
+    [switch] $Debug,
+    [switch] $RegisterSend
 )
 
 $dir_list = Get-ChildItem $dir -Directory | Select-Object Name
@@ -35,6 +36,17 @@ foreach ($d in $dir_list)
 {
     pushd $d.Name
     .\clean.ps1
-    .\build.ps1 -type $build_type
+
+    if ($d.Name -eq "xenbus") {
+        if ($RegisterSend) {
+            .\build.ps1 -type $build_type -RegisterSend
+        } else {
+            .\build.ps1 -type $build_type
+        }
+    } else {
+        .\build.ps1 -type $build_type
+    }
+
+
     popd
 }

--- a/drivers/winpv/xenbus/build.ps1
+++ b/drivers/winpv/xenbus/build.ps1
@@ -5,7 +5,8 @@
 param(
 	[Parameter(Mandatory = $true)]
 	[string]$Type,
-	[switch]$Sdv
+	[switch]$Sdv,
+        [switch]$RegisterSend
 )
 
 #
@@ -26,7 +27,8 @@ Function Win8Build {
 		SolutionDir = $solutiondir[$visualstudioversion];
 		ConfigurationBase = $configurationbase[$visualstudioversion];
 		Arch = $Arch;
-		Type = $Type
+		Type = $Type;
+                RegisterSend = $RegisterSend
 		}
 	& ".\msbuild.ps1" @params
 }
@@ -45,7 +47,8 @@ Function Win10Build {
 		SolutionDir = $solutiondir[$visualstudioversion];
 		ConfigurationBase = $configurationbase[$visualstudioversion];
 		Arch = $Arch;
-		Type = $Type
+		Type = $Type;
+                RegisterSend = $RegisterSend
 		}
 	& ".\msbuild.ps1" @params
 }
@@ -60,7 +63,8 @@ Function SdvBuild {
 		SolutionDir = $solutiondir[$visualstudioversion];
 		ConfigurationBase = $configurationbase[$visualstudioversion];
 		Arch = $arch;
-		Type = "sdv"
+		Type = "sdv";
+                RegisterSend = $RegisterSend
 		}
 	& ".\msbuild.ps1" @params
 }

--- a/drivers/winpv/xenbus/msbuild.ps1
+++ b/drivers/winpv/xenbus/msbuild.ps1
@@ -7,7 +7,8 @@ param(
 	[Parameter(Mandatory = $true)]
 	[string]$Arch,
 	[Parameter(Mandatory = $true)]
-	[string]$Type
+	[string]$Type,
+        [switch]$RegisterSend
 )
 
 Function Run-MSBuild {
@@ -22,6 +23,11 @@ Function Run-MSBuild {
 
 	$c = "msbuild.exe"
 	$c += " /m:4"
+
+        if ($RegisterSend) {
+                $c += " /p:XEN_REGISTER_SEND=1"
+        }
+
 	$c += [string]::Format(" /p:Configuration=""{0}""", $Configuration)
 	$c += [string]::Format(" /p:Platform=""{0}""", $Platform)
 	$c += [string]::Format(" /t:""{0}"" ", $Target)

--- a/drivers/winpv/xenbus/src/xen/event_channel.c
+++ b/drivers/winpv/xenbus/src/xen/event_channel.c
@@ -54,13 +54,17 @@ EventChannelSend(
     IN  evtchn_port_t   LocalPort
     )
 {
-    struct evtchn_send  op;
     LONG_PTR            rc;
     NTSTATUS            status;
 
+#ifndef XEN_REGISTER_SEND
+    struct evtchn_send  op;
     op.port = LocalPort;
 
     rc = EventChannelOp(EVTCHNOP_send, &op);
+#else
+    rc = EventChannelOp(EVTCHNOP_send, (PVOID)LocalPort);
+#endif
 
     if (rc < 0) {
         ERRNO_TO_STATUS(-rc, status);

--- a/drivers/winpv/xenbus/vs2019/xen/xen.vcxproj
+++ b/drivers/winpv/xenbus/vs2019/xen/xen.vcxproj
@@ -22,6 +22,7 @@
     <ClCompile>
       <AdditionalIncludeDirectories>$(WindowsSdkDir)\include\km;..\..\include;..\..\include\xen;..\..\src\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>PROJECT=$(ProjectName);POOL_NX_OPTIN=1;NT_PROCESSOR_GROUPS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(XEN_REGISTER_SEND)'!=''">XEN_REGISTER_SEND;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <WarningLevel>EnableAllWarnings</WarningLevel>
       <DisableSpecificWarnings>4464;4711;4770;4548;4820;4668;4255;5045;6001;6054;26451;28196;30030;30029;%(DisableSpecificWarnings)</DisableSpecificWarnings>

--- a/scripts/cmake/config/default.cmake
+++ b/scripts/cmake/config/default.cmake
@@ -65,3 +65,10 @@ add_config(
     DEFAULT_VAL "/EFI/boot/bootx64.efi"
     DESCRIPTION "Path (relative to ESP mount point) to EFI binary to boot after bareflank.efi"
 )
+
+add_config(
+    CONFIG_NAME XEN_REGISTER_SEND
+    CONFIG_TYPE BOOL
+    DEFAULT_VAL OFF
+    DESCRIPTION "Use a register-based EVTCHNOP_send. Note this requires guest modifications"
+)

--- a/vmm/src/xen/evtchn.cpp
+++ b/vmm/src/xen/evtchn.cpp
@@ -207,10 +207,14 @@ bool xen_evtchn_close(xen_vcpu *v)
 bool xen_evtchn_send(xen_vcpu *v)
 {
     auto uvv = v->m_uv_vcpu;
+#ifndef XEN_REGISTER_SEND
     auto arg = uvv->map_arg<evtchn_send_t>(uvv->rsi());
     auto port = arg->port;
 
     arg.reset(nullptr);
+#else
+    auto port = uvv->rsi();
+#endif
 
     auto ret = v->m_xen_dom->m_evtchn->send(v, port);
 


### PR DESCRIPTION
Add a cmake config option XEN_REGISTER_SEND that when enabled tells the
evtchn code to assume the port of the EVTCHNOP_send hypercall is passed
directly in a register rather than in a evtchn_send_t.

This avoids the need to map in the evtchn_send_t into the VMM, and
thus saves 5 EPT walks and 5 invlpgs per send. This shaves off roughly
half the cost of the send hypercall.

The default value of XEN_REGISTER_SEND is OFF. When it is ON, and
you want to use the Windows PV drivers, you must also pass the
'-registersend' option to xenbus/build.ps1.