### PR TITLE
vmm: Fix TLB invalidation bug

### DIFF
--- a/deps/hypervisor/bfvmm/src/hve/arch/x64/unmapper.cpp
+++ b/deps/hypervisor/bfvmm/src/hve/arch/x64/unmapper.cpp
@@ -51,7 +51,6 @@ unmapper::operator()(void *p) const
 
     for (auto hva = m_hva; hva < m_hva + m_len; hva += page_size) {
         g_cr3->unmap(hva);
-        ::x64::tlb::invlpg(hva);
     }
 
     g_mm->free_map(reinterpret_cast<void *>(m_hva));

--- a/vmm/src/iommu.cpp
+++ b/vmm/src/iommu.cpp
@@ -225,7 +225,6 @@ void iommu::map_regs_into_vmm()
         // contiguous, so we just need to make the map bigger.
 
         g_cr3->unmap(m_reg_hva);
-        ::x64::tlb::invlpg(m_reg_hva);
         g_mm->free_map(reinterpret_cast<void *>(m_reg_hva));
 
         uint64_t size = UV_PAGE_SIZE * m_reg_page_count;

--- a/vmm/src/xen/gnttab.cpp
+++ b/vmm/src/xen/gnttab.cpp
@@ -489,7 +489,6 @@ static inline uint8_t *map_copy_page(const class xen_page *pg)
 static inline void unmap_copy_page(uint8_t *ptr)
 {
     g_cr3->unmap(ptr);
-    ::x64::tlb::invlpg(ptr);
     g_mm->free_map(ptr);
 }
 


### PR DESCRIPTION
The VMM has always used a single set of page tables that is shared with
every CPU. Prior to this change, whenever a virtual address mapping was
freed, invlpg page was used to flush the TLB.  However the other cores
were not shot down, and so the invlpg was only done locally. As soon as
the virtual mappings A/D bits are set, other cores' TLB prefetch
mechanisms are allowed to pull in the entry. Then when that same virtual
address is subsequently mapped on some remote core, the core uses the
stale physical address from the original mapping.

Fix this issue by moving the invlpg to the allocation of the mapping
rather than the freeing.