### PR TITLE
Update includes for the Linux builder driver

### DIFF
--- a/drivers/builder/linux/platform.c
+++ b/drivers/builder/linux/platform.c
@@ -23,7 +23,9 @@
 #include <bfdebug.h>
 #include <bfplatform.h>
 
+#include <linux/kernel.h>
 #include <linux/delay.h>
+#include <linux/io.h>
 #include <linux/mm.h>
 #include <linux/vmalloc.h>
 


### PR DESCRIPTION
fix builds with modern kernels. Tested against
Fedora 32 (5.10.22-100.fc32.x86_64).

Signed-off-by: Brendan Kerrigan <kerriganb@ainfosec.com>