### PR TITLE
Rename XEN_REGISTER_SEND to XEN_REGISTER_BASED_ABI

### DIFF
--- a/.github/workflows/microv.yml
+++ b/.github/workflows/microv.yml
@@ -61,7 +61,7 @@ jobs:
         echo 'set(ENABLE_BUILD_USERSPACE OFF)' >> ../config.cmake
         echo 'set(ENABLE_BUILD_VMM ON)' >> ../config.cmake
         echo 'set(ENABLE_BUILD_EFI ON)' >> ../config.cmake
-        echo 'set(XEN_REGISTER_SEND ON)' >> ../config.cmake
+        echo 'set(XEN_REGISTER_BASED_ABI ON)' >> ../config.cmake
         cmake ../microv/deps/hypervisor -DCONFIG=../config.cmake -DCMAKE_CXX_FLAGS="--verbose "
         make
       shell: bash
@@ -135,7 +135,7 @@ jobs:
     - name: Build Drivers
       run: |
         cd .\microv\drivers
-        .\build-all.ps1 -RegisterSend
+        .\build-all.ps1 -RegisterBasedAbi
       shell: pwsh
 
     - uses: actions/upload-artifact@v2

--- a/deps/hypervisor/scripts/cmake/CMakeLists.txt
+++ b/deps/hypervisor/scripts/cmake/CMakeLists.txt
@@ -130,7 +130,7 @@ target_compile_definitions(bfroot INTERFACE
     $<${VMM_C_CXX}:__SINGLE_THREAD__>
     $<${VMM_C_CXX}:__ELF__>
     $<$<BOOL:${USE_XUE}>:USE_XUE>
-    $<$<BOOL:${XEN_REGISTER_SEND}>:XEN_REGISTER_SEND>
+    $<$<BOOL:${XEN_REGISTER_BASED_ABI}>:XEN_REGISTER_BASED_ABI>
 )
 target_include_directories(bfroot SYSTEM INTERFACE
     $<INSTALL_INTERFACE:$<${VMM_C_CXX}:${VMM_PREFIX_PATH}/include/c++/v1>>

--- a/drivers/build-all.ps1
+++ b/drivers/build-all.ps1
@@ -21,7 +21,7 @@
 
 param(
     [switch] $Debug,
-    [switch] $RegisterSend
+    [switch] $RegisterBasedAbi
 )
 
 $dir_list = Get-ChildItem $dir -Directory | Select-Object Name
@@ -46,8 +46,8 @@ pushd visr\windows
 popd
 
 pushd winpv
-if ($RegisterSend) {
-    .\clean-build.ps1 $Debug -RegisterSend
+if ($RegisterBasedAbi) {
+    .\clean-build.ps1 $Debug -RegisterBasedAbi
 } else {
     .\clean-build.ps1 $Debug
 }

--- a/drivers/winpv/clean-build.ps1
+++ b/drivers/winpv/clean-build.ps1
@@ -21,7 +21,7 @@
 
 param(
     [switch] $Debug,
-    [switch] $RegisterSend
+    [switch] $RegisterBasedAbi
 )
 
 $dir_list = Get-ChildItem $dir -Directory | Select-Object Name
@@ -38,8 +38,8 @@ foreach ($d in $dir_list)
     .\clean.ps1
 
     if ($d.Name -eq "xenbus") {
-        if ($RegisterSend) {
-            .\build.ps1 -type $build_type -RegisterSend
+        if ($RegisterBasedAbi) {
+            .\build.ps1 -type $build_type -RegisterBasedAbi
         } else {
             .\build.ps1 -type $build_type
         }

--- a/drivers/winpv/xenbus/build.ps1
+++ b/drivers/winpv/xenbus/build.ps1
@@ -6,7 +6,7 @@ param(
 	[Parameter(Mandatory = $true)]
 	[string]$Type,
 	[switch]$Sdv,
-        [switch]$RegisterSend
+        [switch]$RegisterBasedAbi
 )
 
 #
@@ -28,7 +28,7 @@ Function Win8Build {
 		ConfigurationBase = $configurationbase[$visualstudioversion];
 		Arch = $Arch;
 		Type = $Type;
-                RegisterSend = $RegisterSend
+                RegisterBasedAbi = $RegisterBasedAbi
 		}
 	& ".\msbuild.ps1" @params
 }
@@ -48,7 +48,7 @@ Function Win10Build {
 		ConfigurationBase = $configurationbase[$visualstudioversion];
 		Arch = $Arch;
 		Type = $Type;
-                RegisterSend = $RegisterSend
+                RegisterBasedAbi = $RegisterBasedAbi
 		}
 	& ".\msbuild.ps1" @params
 }
@@ -64,7 +64,7 @@ Function SdvBuild {
 		ConfigurationBase = $configurationbase[$visualstudioversion];
 		Arch = $arch;
 		Type = "sdv";
-                RegisterSend = $RegisterSend
+                RegisterBasedAbi = $RegisterBasedAbi
 		}
 	& ".\msbuild.ps1" @params
 }

--- a/drivers/winpv/xenbus/msbuild.ps1
+++ b/drivers/winpv/xenbus/msbuild.ps1
@@ -8,7 +8,7 @@ param(
 	[string]$Arch,
 	[Parameter(Mandatory = $true)]
 	[string]$Type,
-        [switch]$RegisterSend
+        [switch]$RegisterBasedAbi
 )
 
 Function Run-MSBuild {
@@ -24,8 +24,8 @@ Function Run-MSBuild {
 	$c = "msbuild.exe"
 	$c += " /m:4"
 
-        if ($RegisterSend) {
-                $c += " /p:XEN_REGISTER_SEND=1"
+        if ($RegisterBasedAbi) {
+                $c += " /p:XEN_REGISTER_BASED_ABI=1"
         }
 
 	$c += [string]::Format(" /p:Configuration=""{0}""", $Configuration)

--- a/drivers/winpv/xenbus/src/xen/event_channel.c
+++ b/drivers/winpv/xenbus/src/xen/event_channel.c
@@ -57,7 +57,7 @@ EventChannelSend(
     LONG_PTR            rc;
     NTSTATUS            status;
 
-#ifndef XEN_REGISTER_SEND
+#ifndef XEN_REGISTER_BASED_ABI
     struct evtchn_send  op;
     op.port = LocalPort;
 

--- a/drivers/winpv/xenbus/vs2019/xen/xen.vcxproj
+++ b/drivers/winpv/xenbus/vs2019/xen/xen.vcxproj
@@ -22,7 +22,7 @@
     <ClCompile>
       <AdditionalIncludeDirectories>$(WindowsSdkDir)\include\km;..\..\include;..\..\include\xen;..\..\src\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>PROJECT=$(ProjectName);POOL_NX_OPTIN=1;NT_PROCESSOR_GROUPS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <PreprocessorDefinitions Condition="'$(XEN_REGISTER_SEND)'!=''">XEN_REGISTER_SEND;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(XEN_REGISTER_BASED_ABI)'!=''">XEN_REGISTER_BASED_ABI;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <WarningLevel>EnableAllWarnings</WarningLevel>
       <DisableSpecificWarnings>4464;4711;4770;4548;4820;4668;4255;5045;6001;6054;26451;28196;30030;30029;%(DisableSpecificWarnings)</DisableSpecificWarnings>

--- a/scripts/cmake/config/default.cmake
+++ b/scripts/cmake/config/default.cmake
@@ -67,7 +67,7 @@ add_config(
 )
 
 add_config(
-    CONFIG_NAME XEN_REGISTER_SEND
+    CONFIG_NAME XEN_REGISTER_BASED_ABI
     CONFIG_TYPE BOOL
     DEFAULT_VAL OFF
     DESCRIPTION "Use a register-based EVTCHNOP_send. Note this requires guest modifications"

--- a/vmm/src/xen/evtchn.cpp
+++ b/vmm/src/xen/evtchn.cpp
@@ -207,7 +207,7 @@ bool xen_evtchn_close(xen_vcpu *v)
 bool xen_evtchn_send(xen_vcpu *v)
 {
     auto uvv = v->m_uv_vcpu;
-#ifndef XEN_REGISTER_SEND
+#ifndef XEN_REGISTER_BASED_ABI
     auto arg = uvv->map_arg<evtchn_send_t>(uvv->rsi());
     auto port = arg->port;
 


### PR DESCRIPTION
This was accidentally left out of merge ce89996. Use the
XEN_REGISTER_BASED_ABI hypervisor config option and -RegisterBasedAbi
for building the Windows drivers with support for passing the send
port in a register instead of memory.