### PR TITLE
microv.yml: Add nightly and manual Actions triggers

### DIFF
--- a/.github/workflows/microv.yml
+++ b/.github/workflows/microv.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     paths-ignore:
       - '**.md'
+  workflow_dispatch:
+    paths-ignore:
+      - '**.md'
+  schedule:
+    - cron: '45 1 * * *'
+    paths-ignore:
+      - '**.md'
 
 jobs:
 


### PR DESCRIPTION
Add the 'workflow_dispatch' event for enabling manual triggers from
the Github website

Add the 'schedule' event for nightly builds (1:45AM UTC)