### PR TITLE
Driver fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,12 +84,14 @@ drivers/builder/windows/vs2019/builder/smvstats.txt
 drivers/builder/windows/vs2019/package/Windows10Debug/
 drivers/builder/windows/vs2019/package/Windows10Release/
 
+drivers/visr/windows/version.h
 drivers/visr/windows/x64
 drivers/visr/windows/.build_number
 drivers/visr/windows/visr/
 drivers/visr/windows/vs2019/Windows10Release/
 drivers/visr/windows/vs2019/package/Windows10Debug/
 drivers/visr/windows/vs2019/package/Windows10Release/
+drivers/visr/windows/vs2019/version/.revision
 drivers/visr/windows/vs2019/visr.DVL.XML
 drivers/visr/windows/vs2019/visr/Windows10Debug/
 drivers/visr/windows/vs2019/visr/Windows10Release/

--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ deploy/windows/images
 *.sqlite
 *.manifest
 
+drivers/builder/windows/version.h
 drivers/builder/windows/x64
 drivers/builder/windows/.build_number
 drivers/builder/windows/builder/
@@ -83,6 +84,7 @@ drivers/builder/windows/vs2019/builder/smvexecute-NormalBuild.log
 drivers/builder/windows/vs2019/builder/smvstats.txt
 drivers/builder/windows/vs2019/package/Windows10Debug/
 drivers/builder/windows/vs2019/package/Windows10Release/
+drivers/builder/windows/vs2019/version/.revision
 
 drivers/visr/windows/version.h
 drivers/visr/windows/x64

--- a/drivers/builder/windows/builder.rc
+++ b/drivers/builder/windows/builder.rc
@@ -1,0 +1,56 @@
+/* Copyright (c) Citrix Systems Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ * *   Redistributions of source code must retain the above
+ *     copyright notice, this list of conditions and the
+ *     following disclaimer.
+ * *   Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the
+ *     following disclaimer in the documentation and/or other
+ *     materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <windows.h>
+#include <ntverp.h>
+
+
+#undef VER_COMPANYNAME_STR
+#undef VER_PRODUCTNAME_STR
+#undef VER_PRODUCTVERSION
+#undef VER_PRODUCTVERSION_STR
+
+#include <version.h>
+
+#define	VER_COMPANYNAME_STR         VENDOR_NAME_STR
+#define VER_LEGALCOPYRIGHT_STR      "Copyright (c) Assured Information Security, Inc."
+
+#define VER_PRODUCTNAME_STR         "BUILDER"
+#define VER_PRODUCTVERSION          MAJOR_VERSION,MINOR_VERSION,MICRO_VERSION,BUILD_NUMBER
+#define VER_PRODUCTVERSION_STR      MAJOR_VERSION_STR "." MINOR_VERSION_STR "." MICRO_VERSION_STR "." BUILD_NUMBER_STR
+
+#define VER_INTERNALNAME_STR        "BUILDER.SYS"
+#define VER_FILEDESCRIPTION_STR     "BUILDER"
+
+#define VER_FILETYPE                VFT_DRV
+#define VER_FILESUBTYPE             VFT2_DRV_SYSTEM
+
+#include <common.ver>

--- a/drivers/builder/windows/version.tmpl
+++ b/drivers/builder/windows/version.tmpl
@@ -1,0 +1,22 @@
+#define VENDOR_NAME_STR      "@VENDOR_NAME@"
+#define PRODUCT_NAME_STR     "@PRODUCT_NAME@"
+#define VENDOR_PREFIX_STR    "@VENDOR_PREFIX@"
+#define VENDOR_DEVICE_ID_STR "@VENDOR_DEVICE_ID@"
+
+#define MAJOR_VERSION_STR    "@MAJOR_VERSION@"
+#define MINOR_VERSION_STR    "@MINOR_VERSION@"
+#define MICRO_VERSION_STR    "@MICRO_VERSION@"
+#define BUILD_NUMBER_STR     "@BUILD_NUMBER@"
+
+#define YEAR_STR             "@YEAR@"
+#define MONTH_STR            "@MONTH@"
+#define DAY_STR              "@DAY@"
+
+#define MAJOR_VERSION        @MAJOR_VERSION@
+#define MINOR_VERSION        @MINOR_VERSION@
+#define MICRO_VERSION        @MICRO_VERSION@
+#define BUILD_NUMBER         @BUILD_NUMBER@
+
+#define YEAR                 @YEAR@
+#define MONTH                @MONTH@
+#define DAY                  @DAY@

--- a/drivers/builder/windows/vs2019/builder/builder.vcxproj
+++ b/drivers/builder/windows/vs2019/builder/builder.vcxproj
@@ -46,6 +46,9 @@
       <OutDir>..\$(ConfigurationName)\$(Platform)\</OutDir>
       <IncludePath>..\..\..\..\..\deps\hypervisor\bfsdk\include;..\..\..\..\..\deps\hypervisor\bfelf_loader\include;..\..\..\..\..\include;..\..\..\..\..\deps\xen\xen\include\public;..\..\..\;..\..\;$(IncludePath)</IncludePath>
   </PropertyGroup>
+  <PropertyGroup>
+    <SignMode>Off</SignMode>
+  </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
       <WarningLevel>EnableAllWarnings</WarningLevel>
@@ -85,6 +88,9 @@
   </ItemGroup>
   <ItemGroup>
     <MASM Include="..\..\intrinsics.asm" />
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="..\..\builder.rc" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/drivers/builder/windows/vs2019/package/package.vcxproj
+++ b/drivers/builder/windows/vs2019/package/package.vcxproj
@@ -16,6 +16,7 @@
   <Import Project="..\targets.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <PropertyGroup>
+    <SignMode>TestSign</SignMode>
     <EnableInf2cat>true</EnableInf2cat>
     <Inf2CatWindowsVersionList Condition="'$(Platform)'=='x64'">10_x64</Inf2CatWindowsVersionList>
     <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>

--- a/drivers/visr/windows/genfiles.ps1
+++ b/drivers/visr/windows/genfiles.ps1
@@ -2,7 +2,8 @@
 # Generate visr.inf
 #
 param(
-	[string]$SolutionDir = "vs2019"
+	[string]$SolutionDir = "vs2019",
+	[string]$Platform = "x64"
 )
 
 # Copy $InFileName -> $OutFileName replacing $Token$_.Key$Token with $_.Value from
@@ -39,15 +40,39 @@ Function Copy-FileWithReplacements {
 #
 # Script Body
 #
+$TheYear = [int](Get-Date -UFormat "%Y")
+$TheMonth = [int](Get-Date -UFormat "%m")
+$TheDay = [int](Get-Date -UFormat "%d")
+$InfArch = @{ "Win32" = "x86"; "x64" = "amd64" }
 $InfDate = Get-Date -UFormat "%m/%d/%Y"
+
+# if GitRevision is $null, GIT_REVISION will be excluded from the Copy-FileWithReplacements
+$GitRevision = & "git.exe" "rev-list" "--max-count=1" "HEAD"
+if ($GitRevision) {
+	Set-Content -Path ".revision" -Value $GitRevision
+}
 
 # [ordered] makes output easier to parse by humans
 $Replacements = [ordered]@{
+	# values determined from the build environment
+	'VENDOR_NAME' = $Env:VENDOR_NAME;
+	'PRODUCT_NAME' = $Env:PRODUCT_NAME;
+	'VENDOR_DEVICE_ID' = $Env:VENDOR_DEVICE_ID;
+	'VENDOR_PREFIX' = $Env:VENDOR_PREFIX;
+
 	'MAJOR_VERSION' = $Env:MAJOR_VERSION;
 	'MINOR_VERSION' = $Env:MINOR_VERSION;
 	'MICRO_VERSION' = $Env:MICRO_VERSION;
 	'BUILD_NUMBER' = $Env:BUILD_NUMBER;
+
+	# generated values
+	'GIT_REVISION' = $GitRevision;
+
 	'INF_DATE' = $InfDate;
+	'INF_ARCH' = $InfArch[$Platform];
+	'YEAR' = $TheYear;
+	'MONTH' = $TheMonth;
+	'DAY' = $TheDay
 }
 
 $Replacements | Out-String | Write-Host
@@ -57,4 +82,8 @@ $slnpath | Out-String | Write-Host
 
 $src = "$PSScriptRoot\visr.inf"
 $dst = Join-Path -Path $slnpath -ChildPath "visr\visr.inf"
+Copy-FileWithReplacements $src $dst -Replacements $Replacements
+
+$src = "$PSScriptRoot\version.tmpl"
+$dst = "$PSScriptRoot\version.h"
 Copy-FileWithReplacements $src $dst -Replacements $Replacements

--- a/drivers/visr/windows/version.tmpl
+++ b/drivers/visr/windows/version.tmpl
@@ -1,0 +1,22 @@
+#define VENDOR_NAME_STR      "@VENDOR_NAME@"
+#define PRODUCT_NAME_STR     "@PRODUCT_NAME@"
+#define VENDOR_PREFIX_STR    "@VENDOR_PREFIX@"
+#define VENDOR_DEVICE_ID_STR "@VENDOR_DEVICE_ID@"
+
+#define MAJOR_VERSION_STR    "@MAJOR_VERSION@"
+#define MINOR_VERSION_STR    "@MINOR_VERSION@"
+#define MICRO_VERSION_STR    "@MICRO_VERSION@"
+#define BUILD_NUMBER_STR     "@BUILD_NUMBER@"
+
+#define YEAR_STR             "@YEAR@"
+#define MONTH_STR            "@MONTH@"
+#define DAY_STR              "@DAY@"
+
+#define MAJOR_VERSION        @MAJOR_VERSION@
+#define MINOR_VERSION        @MINOR_VERSION@
+#define MICRO_VERSION        @MICRO_VERSION@
+#define BUILD_NUMBER         @BUILD_NUMBER@
+
+#define YEAR                 @YEAR@
+#define MONTH                @MONTH@
+#define DAY                  @DAY@

--- a/drivers/visr/windows/visr.rc
+++ b/drivers/visr/windows/visr.rc
@@ -1,0 +1,56 @@
+/* Copyright (c) Citrix Systems Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ * *   Redistributions of source code must retain the above
+ *     copyright notice, this list of conditions and the
+ *     following disclaimer.
+ * *   Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the
+ *     following disclaimer in the documentation and/or other
+ *     materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <windows.h>
+#include <ntverp.h>
+
+
+#undef VER_COMPANYNAME_STR
+#undef VER_PRODUCTNAME_STR
+#undef VER_PRODUCTVERSION
+#undef VER_PRODUCTVERSION_STR
+
+#include <version.h>
+
+#define	VER_COMPANYNAME_STR         VENDOR_NAME_STR
+#define VER_LEGALCOPYRIGHT_STR      "Copyright (c) Assured Information Security, Inc."
+
+#define VER_PRODUCTNAME_STR         "VISR"
+#define VER_PRODUCTVERSION          MAJOR_VERSION,MINOR_VERSION,MICRO_VERSION,BUILD_NUMBER
+#define VER_PRODUCTVERSION_STR      MAJOR_VERSION_STR "." MINOR_VERSION_STR "." MICRO_VERSION_STR "." BUILD_NUMBER_STR
+
+#define VER_INTERNALNAME_STR        "VISR.SYS"
+#define VER_FILEDESCRIPTION_STR     "VISR"
+
+#define VER_FILETYPE                VFT_DRV
+#define VER_FILESUBTYPE             VFT2_DRV_SYSTEM
+
+#include <common.ver>

--- a/drivers/visr/windows/vs2019/package/package.vcxproj
+++ b/drivers/visr/windows/vs2019/package/package.vcxproj
@@ -16,6 +16,7 @@
   <Import Project="..\targets.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <PropertyGroup>
+    <SignMode>TestSign</SignMode>
     <EnableInf2cat>true</EnableInf2cat>
     <Inf2CatWindowsVersionList Condition="'$(Platform)'=='x64'">10_x64</Inf2CatWindowsVersionList>
     <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>

--- a/drivers/visr/windows/vs2019/visr/visr.vcxproj
+++ b/drivers/visr/windows/vs2019/visr/visr.vcxproj
@@ -46,6 +46,9 @@
       <OutDir>..\$(ConfigurationName)\$(Platform)\</OutDir>
       <IncludePath>..\..\..\..\..\deps\hypervisor\bfsdk\include;..\..\..\..\..\deps\hypervisor\bfelf_loader\include;..\..\..\..\..\include;..\..\;$(IncludePath)</IncludePath>
   </PropertyGroup>
+  <PropertyGroup>
+    <SignMode>Off</SignMode>
+  </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
       <WarningLevel>EnableAllWarnings</WarningLevel>
@@ -80,6 +83,9 @@
   </ItemGroup>
   <ItemGroup>
     <MASM Include="..\..\intrinsics.asm" />
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="..\..\visr.rc" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/drivers/winpv/xenbus/include/xen-errno.h
+++ b/drivers/winpv/xenbus/include/xen-errno.h
@@ -38,7 +38,10 @@
 
 #define EISDIR      21
 #define EROFS       30
+
+#ifndef ENOTEMPTY
 #define ENOTEMPTY   39
+#endif
 
 #pragma warning(disable:4127)   // conditional expression is constant
 

--- a/drivers/winpv/xenbus/include/xen.h
+++ b/drivers/winpv/xenbus/include/xen.h
@@ -53,7 +53,9 @@
 // part of an enumeration and the #ifdef test thus fails.
 // Override the enumeration value here with a #define.
 
+#ifndef EINVAL
 #define EINVAL  XEN_EINVAL
+#endif
 
 #include <public/io/xs_wire.h>
 #include <public/io/console.h>

--- a/drivers/winpv/xenbus/include/xen/xen/errno.h
+++ b/drivers/winpv/xenbus/include/xen/xen/errno.h
@@ -3,7 +3,7 @@
 
 #ifndef __ASSEMBLY__
 
-#define XEN_ERRNO(name, value) name = value,
+#define XEN_ERRNO(name, value) WINPV_##name = value,
 enum {
 #include <public/errno.h>
 };

--- a/drivers/winpv/xenbus/vs2019/xen/xen.vcxproj
+++ b/drivers/winpv/xenbus/vs2019/xen/xen.vcxproj
@@ -21,7 +21,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>$(WindowsSdkDir)\include\km;..\..\include;..\..\include\xen;..\..\src\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>PROJECT=$(ProjectName);POOL_NX_OPTIN=1;NT_PROCESSOR_GROUPS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_NO_CRT_STDIO_INLINE;PROJECT=$(ProjectName);POOL_NX_OPTIN=1;NT_PROCESSOR_GROUPS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(XEN_REGISTER_BASED_ABI)'!=''">XEN_REGISTER_BASED_ABI;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <WarningLevel>EnableAllWarnings</WarningLevel>

--- a/drivers/winpv/xenbus/vs2019/xen/xen.vcxproj.user
+++ b/drivers/winpv/xenbus/vs2019/xen/xen.vcxproj.user
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <SignMode>TestSign</SignMode>
+    <SignMode>Off</SignMode>
     <TestCertificate>..\..\src\xenbus.pfx</TestCertificate>
     <TimeStampServer>http://timestamp.verisign.com/scripts/timstamp.dll</TimeStampServer>
   </PropertyGroup>

--- a/drivers/winpv/xenbus/vs2019/xenbus/xenbus.vcxproj
+++ b/drivers/winpv/xenbus/vs2019/xenbus/xenbus.vcxproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>PROJECT=$(ProjectName);POOL_NX_OPTIN=1;NT_PROCESSOR_GROUPS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_NO_CRT_STDIO_INLINE;PROJECT=$(ProjectName);POOL_NX_OPTIN=1;NT_PROCESSOR_GROUPS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <AdditionalIncludeDirectories>$(WindowsSdkDir)\include\km;..\..\include;..\..\include\xen;..\..\src\common;..\..\..\..\..\include;..\..\..\..\..\deps\hypervisor\bfsdk\include;</AdditionalIncludeDirectories>
       <WarningLevel>EnableAllWarnings</WarningLevel>

--- a/drivers/winpv/xenbus/vs2019/xenbus/xenbus.vcxproj.user
+++ b/drivers/winpv/xenbus/vs2019/xenbus/xenbus.vcxproj.user
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <SignMode>TestSign</SignMode>
+    <SignMode>Off</SignMode>
     <TestCertificate>..\..\src\xenbus.pfx</TestCertificate>
     <TimeStampServer>http://timestamp.verisign.com/scripts/timstamp.dll</TimeStampServer>
   </PropertyGroup>

--- a/drivers/winpv/xenbus/vs2019/xenbus_coinst/xenbus_coinst.vcxproj.user
+++ b/drivers/winpv/xenbus/vs2019/xenbus_coinst/xenbus_coinst.vcxproj.user
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <SignMode>TestSign</SignMode>
+    <SignMode>Off</SignMode>
     <TestCertificate>..\..\src\xenbus.pfx</TestCertificate>
     <TimeStampServer>http://timestamp.verisign.com/scripts/timstamp.dll</TimeStampServer>
   </PropertyGroup>

--- a/drivers/winpv/xenbus/vs2019/xenbus_monitor/xenbus_monitor.vcxproj.user
+++ b/drivers/winpv/xenbus/vs2019/xenbus_monitor/xenbus_monitor.vcxproj.user
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <SignMode>TestSign</SignMode>
+    <SignMode>Off</SignMode>
     <TestCertificate>..\..\src\xenbus.pfx</TestCertificate>
     <TimeStampServer>http://timestamp.verisign.com/scripts/timstamp.dll</TimeStampServer>
   </PropertyGroup>

--- a/drivers/winpv/xeniface/vs2019/xeniface/xeniface.vcxproj
+++ b/drivers/winpv/xeniface/vs2019/xeniface/xeniface.vcxproj
@@ -21,7 +21,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>$(WindowsSdkDir)\include\km;..\..\include;</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>PROJECT=$(ProjectName);POOL_NX_OPTIN=1;NT_PROCESSOR_GROUPS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_NO_CRT_STDIO_INLINE;PROJECT=$(ProjectName);POOL_NX_OPTIN=1;NT_PROCESSOR_GROUPS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <WarningLevel>EnableAllWarnings</WarningLevel>
       <DisableSpecificWarnings>4464;4711;4548;4770;4820;4668;4255;5045;6001;6054;26451;28160;30030;30029;%(DisableSpecificWarnings)</DisableSpecificWarnings>

--- a/drivers/winpv/xeniface/vs2019/xeniface/xeniface.vcxproj.user
+++ b/drivers/winpv/xeniface/vs2019/xeniface/xeniface.vcxproj.user
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <SignMode>TestSign</SignMode>
+    <SignMode>Off</SignMode>
     <TestCertificate>..\..\src\xeniface.pfx</TestCertificate>
     <TimeStampServer>http://timestamp.verisign.com/scripts/timstamp.dll</TimeStampServer>
   </PropertyGroup>

--- a/drivers/winpv/xeniface/vs2019/xeniface_coinst/xeniface_coinst.vcxproj.user
+++ b/drivers/winpv/xeniface/vs2019/xeniface_coinst/xeniface_coinst.vcxproj.user
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <SignMode>TestSign</SignMode>
+    <SignMode>Off</SignMode>
     <TestCertificate>..\..\src\xeniface.pfx</TestCertificate>
     <TimeStampServer>http://timestamp.verisign.com/scripts/timstamp.dll</TimeStampServer>
   </PropertyGroup>

--- a/drivers/winpv/xennet/vs2019/xennet/xennet.vcxproj
+++ b/drivers/winpv/xennet/vs2019/xennet/xennet.vcxproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>PROJECT=$(ProjectName);NDIS_MINIPORT_DRIVER;NDIS_WDM=1;NDIS61_MINIPORT=1;POOL_NX_OPTIN=1;NT_PROCESSOR_GROUPS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_NO_CRT_STDIO_INLINE;PROJECT=$(ProjectName);NDIS_MINIPORT_DRIVER;NDIS_WDM=1;NDIS61_MINIPORT=1;POOL_NX_OPTIN=1;NT_PROCESSOR_GROUPS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <AdditionalIncludeDirectories>$(WindowsSdkDir)\include\km;..\..\include;..\..\include\xen;</AdditionalIncludeDirectories>
       <WarningLevel>EnableAllWarnings</WarningLevel>

--- a/drivers/winpv/xennet/vs2019/xennet/xennet.vcxproj.user
+++ b/drivers/winpv/xennet/vs2019/xennet/xennet.vcxproj.user
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <SignMode>TestSign</SignMode>
+    <SignMode>Off</SignMode>
     <TestCertificate>..\..\src\xennet.pfx</TestCertificate>
     <TimeStampServer>http://timestamp.verisign.com/scripts/timstamp.dll</TimeStampServer>
   </PropertyGroup>

--- a/drivers/winpv/xennet/vs2019/xennet_coinst/xennet_coinst.vcxproj.user
+++ b/drivers/winpv/xennet/vs2019/xennet_coinst/xennet_coinst.vcxproj.user
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <SignMode>TestSign</SignMode>
+    <SignMode>Off</SignMode>
     <TestCertificate>..\..\src\xennet.pfx</TestCertificate>
     <TimeStampServer>http://timestamp.verisign.com/scripts/timstamp.dll</TimeStampServer>
   </PropertyGroup>

--- a/drivers/winpv/xenvif/include/xen-types.h
+++ b/drivers/winpv/xenvif/include/xen-types.h
@@ -46,7 +46,9 @@ typedef USHORT  uint16_t;
 typedef ULONG   uint32_t;
 typedef ULONG64 uint64_t;
 
+#ifndef offsetof
 #define offsetof(_type, _field) FIELD_OFFSET(_type, _field)
+#endif
 
 #define xen_mb()    KeMemoryBarrier()
 #define xen_wmb()   KeMemoryBarrier()

--- a/drivers/winpv/xenvif/vs2019/xenvif/xenvif.vcxproj
+++ b/drivers/winpv/xenvif/vs2019/xenvif/xenvif.vcxproj
@@ -21,7 +21,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>$(WindowsSdkDir)\include\km;..\..\include;..\..\include\xen;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>PROJECT=$(ProjectName);POOL_NX_OPTIN=1;NT_PROCESSOR_GROUPS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_NO_CRT_STDIO_INLINE;PROJECT=$(ProjectName);POOL_NX_OPTIN=1;NT_PROCESSOR_GROUPS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <WarningLevel>EnableAllWarnings</WarningLevel>
       <DisableSpecificWarnings>4464;4711;4770;4548;4820;4668;4255;5045;6001;6054;26451;28196;30030;30029;%(DisableSpecificWarnings)</DisableSpecificWarnings>

--- a/drivers/winpv/xenvif/vs2019/xenvif/xenvif.vcxproj.user
+++ b/drivers/winpv/xenvif/vs2019/xenvif/xenvif.vcxproj.user
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <SignMode>TestSign</SignMode>
+    <SignMode>Off</SignMode>
     <TestCertificate>..\..\src\xenvif.pfx</TestCertificate>
     <TimeStampServer>http://timestamp.verisign.com/scripts/timstamp.dll</TimeStampServer>
   </PropertyGroup>

--- a/drivers/winpv/xenvif/vs2019/xenvif_coinst/xenvif_coinst.vcxproj.user
+++ b/drivers/winpv/xenvif/vs2019/xenvif_coinst/xenvif_coinst.vcxproj.user
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <SignMode>TestSign</SignMode>
+    <SignMode>Off</SignMode>
     <TestCertificate>..\..\src\xenvif.pfx</TestCertificate>
     <TimeStampServer>http://timestamp.verisign.com/scripts/timstamp.dll</TimeStampServer>
   </PropertyGroup>


### PR DESCRIPTION
This series fixes several issues with the drivers:

- Remove test-signing in individual driver vcxprojs for WHQL submission
- Add visr.rc and builder.rc to fill out proper Product Version, Copyright, etc. info for WHQL submission
- Fix the winpv driver builds from the latest breakage from VS update