### PR TITLE
[mono] drivers: re-enable test signing and add nocerts artifact

### DIFF
--- a/.github/workflows/microv.yml
+++ b/.github/workflows/microv.yml
@@ -160,3 +160,50 @@ jobs:
           microv/drivers/winpv/xeniface/vs2019/Windows10Release/x64/xeniface.cer
           microv/drivers/winpv/xeniface/include/xencontrol.h
           microv/drivers/winpv/xeniface/include/xeniface_ioctls.h
+
+  build-drivers-nocerts:
+    runs-on: windows-2019
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        path: microv
+
+    - name: Setup MSBuild (PATH)
+      id: setup_msbuild_path
+      uses: microsoft/setup-msbuild@v1.0.2
+
+    - name: Setup
+      run: |
+        # Get dependencies
+        $MSBUILD_PATH = "${{steps.setup_msbuild_path.outputs.msbuildPath}}"
+        echo "msbuild path: $MSBUILD_PATH"
+        echo $MSBUILD_PATH | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        choco install nasm
+        echo "C:\Program Files\NASM" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        # Set latest build number
+        $runs = Invoke-WebRequest -Headers @{"Authorization" = 'token ${{ secrets.GITHUB_TOKEN }}'} -Uri 'https://api.github.com/repos/bareflank/microv/actions/runs?branch=mono&status=success' | ConvertFrom-Json
+        Add-Content -Path $Env:GITHUB_ENV -Value "BUILD_NUMBER=$($runs.total_count + 10)"
+      shell: pwsh
+
+    - name: Build Drivers with Test Sign Off
+      run: |
+        cd .\microv\drivers
+        $SignOff = '<SignMode>Off</SignMode>'
+        $SignTest = '<SignMode>TestSign</SignMode>'
+        $Files = Get-ChildItem -Recurse | Select-String $SignTest -List
+        foreach ($f in $Files.Path) { (Get-Content $f) -replace $SignTest, $SignOff | Set-Content $f }
+        .\build-all.ps1 -RegisterBasedAbi
+      shell: pwsh
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: microv_drivers_nocerts
+        path: |
+          microv/drivers/builder/windows/builder/x64/*
+          microv/drivers/visr/windows/visr/x64/*
+          microv/drivers/winpv/xenbus/xenbus/x64/*
+          microv/drivers/winpv/xennet/xennet/x64/*
+          microv/drivers/winpv/xenvif/xenvif/x64/*
+          microv/drivers/winpv/xeniface/xeniface/x64/*
+          microv/drivers/winpv/xeniface/include/xencontrol.h
+          microv/drivers/winpv/xeniface/include/xeniface_ioctls.h

--- a/drivers/builder/windows/vs2019/builder/builder.vcxproj
+++ b/drivers/builder/windows/vs2019/builder/builder.vcxproj
@@ -47,7 +47,7 @@
       <IncludePath>..\..\..\..\..\deps\hypervisor\bfsdk\include;..\..\..\..\..\deps\hypervisor\bfelf_loader\include;..\..\..\..\..\include;..\..\..\..\..\deps\xen\xen\include\public;..\..\..\;..\..\;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup>
-    <SignMode>Off</SignMode>
+    <SignMode>TestSign</SignMode>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/drivers/visr/windows/vs2019/visr/visr.vcxproj
+++ b/drivers/visr/windows/vs2019/visr/visr.vcxproj
@@ -47,7 +47,7 @@
       <IncludePath>..\..\..\..\..\deps\hypervisor\bfsdk\include;..\..\..\..\..\deps\hypervisor\bfelf_loader\include;..\..\..\..\..\include;..\..\;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup>
-    <SignMode>Off</SignMode>
+    <SignMode>TestSign</SignMode>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/drivers/winpv/xenbus/vs2019/xen/xen.vcxproj.user
+++ b/drivers/winpv/xenbus/vs2019/xen/xen.vcxproj.user
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <SignMode>Off</SignMode>
+    <SignMode>TestSign</SignMode>
     <TestCertificate>..\..\src\xenbus.pfx</TestCertificate>
     <TimeStampServer>http://timestamp.verisign.com/scripts/timstamp.dll</TimeStampServer>
   </PropertyGroup>

--- a/drivers/winpv/xenbus/vs2019/xenbus/xenbus.vcxproj.user
+++ b/drivers/winpv/xenbus/vs2019/xenbus/xenbus.vcxproj.user
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <SignMode>Off</SignMode>
+    <SignMode>TestSign</SignMode>
     <TestCertificate>..\..\src\xenbus.pfx</TestCertificate>
     <TimeStampServer>http://timestamp.verisign.com/scripts/timstamp.dll</TimeStampServer>
   </PropertyGroup>

--- a/drivers/winpv/xenbus/vs2019/xenbus_coinst/xenbus_coinst.vcxproj.user
+++ b/drivers/winpv/xenbus/vs2019/xenbus_coinst/xenbus_coinst.vcxproj.user
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <SignMode>Off</SignMode>
+    <SignMode>TestSign</SignMode>
     <TestCertificate>..\..\src\xenbus.pfx</TestCertificate>
     <TimeStampServer>http://timestamp.verisign.com/scripts/timstamp.dll</TimeStampServer>
   </PropertyGroup>

--- a/drivers/winpv/xenbus/vs2019/xenbus_monitor/xenbus_monitor.vcxproj.user
+++ b/drivers/winpv/xenbus/vs2019/xenbus_monitor/xenbus_monitor.vcxproj.user
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <SignMode>Off</SignMode>
+    <SignMode>TestSign</SignMode>
     <TestCertificate>..\..\src\xenbus.pfx</TestCertificate>
     <TimeStampServer>http://timestamp.verisign.com/scripts/timstamp.dll</TimeStampServer>
   </PropertyGroup>

--- a/drivers/winpv/xeniface/vs2019/xeniface/xeniface.vcxproj.user
+++ b/drivers/winpv/xeniface/vs2019/xeniface/xeniface.vcxproj.user
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <SignMode>Off</SignMode>
+    <SignMode>TestSign</SignMode>
     <TestCertificate>..\..\src\xeniface.pfx</TestCertificate>
     <TimeStampServer>http://timestamp.verisign.com/scripts/timstamp.dll</TimeStampServer>
   </PropertyGroup>

--- a/drivers/winpv/xeniface/vs2019/xeniface_coinst/xeniface_coinst.vcxproj.user
+++ b/drivers/winpv/xeniface/vs2019/xeniface_coinst/xeniface_coinst.vcxproj.user
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <SignMode>Off</SignMode>
+    <SignMode>TestSign</SignMode>
     <TestCertificate>..\..\src\xeniface.pfx</TestCertificate>
     <TimeStampServer>http://timestamp.verisign.com/scripts/timstamp.dll</TimeStampServer>
   </PropertyGroup>

--- a/drivers/winpv/xennet/vs2019/xennet/xennet.vcxproj.user
+++ b/drivers/winpv/xennet/vs2019/xennet/xennet.vcxproj.user
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <SignMode>Off</SignMode>
+    <SignMode>TestSign</SignMode>
     <TestCertificate>..\..\src\xennet.pfx</TestCertificate>
     <TimeStampServer>http://timestamp.verisign.com/scripts/timstamp.dll</TimeStampServer>
   </PropertyGroup>

--- a/drivers/winpv/xennet/vs2019/xennet_coinst/xennet_coinst.vcxproj.user
+++ b/drivers/winpv/xennet/vs2019/xennet_coinst/xennet_coinst.vcxproj.user
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <SignMode>Off</SignMode>
+    <SignMode>TestSign</SignMode>
     <TestCertificate>..\..\src\xennet.pfx</TestCertificate>
     <TimeStampServer>http://timestamp.verisign.com/scripts/timstamp.dll</TimeStampServer>
   </PropertyGroup>

--- a/drivers/winpv/xenvif/vs2019/xenvif/xenvif.vcxproj.user
+++ b/drivers/winpv/xenvif/vs2019/xenvif/xenvif.vcxproj.user
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <SignMode>Off</SignMode>
+    <SignMode>TestSign</SignMode>
     <TestCertificate>..\..\src\xenvif.pfx</TestCertificate>
     <TimeStampServer>http://timestamp.verisign.com/scripts/timstamp.dll</TimeStampServer>
   </PropertyGroup>

--- a/drivers/winpv/xenvif/vs2019/xenvif_coinst/xenvif_coinst.vcxproj.user
+++ b/drivers/winpv/xenvif/vs2019/xenvif_coinst/xenvif_coinst.vcxproj.user
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <SignMode>Off</SignMode>
+    <SignMode>TestSign</SignMode>
     <TestCertificate>..\..\src\xenvif.pfx</TestCertificate>
     <TimeStampServer>http://timestamp.verisign.com/scripts/timstamp.dll</TimeStampServer>
   </PropertyGroup>


### PR DESCRIPTION
This patch re-enables test signing for the `microv_drivers.zip` artifact and creates a new `microv_drivers_nocerts.zip` built with test signing disabled.