### PR TITLE
[mono] winpv: Fix compilation error on latest VS

### DIFF
--- a/drivers/winpv/xenbus/include/xen-errno.h
+++ b/drivers/winpv/xenbus/include/xen-errno.h
@@ -38,10 +38,7 @@
 
 #define EISDIR      21
 #define EROFS       30
-
-#ifndef ENOTEMPTY
 #define ENOTEMPTY   39
-#endif
 
 #pragma warning(disable:4127)   // conditional expression is constant
 

--- a/drivers/winpv/xenbus/include/xen.h
+++ b/drivers/winpv/xenbus/include/xen.h
@@ -53,9 +53,7 @@
 // part of an enumeration and the #ifdef test thus fails.
 // Override the enumeration value here with a #define.
 
-#ifndef EINVAL
 #define EINVAL  XEN_EINVAL
-#endif
 
 #include <public/io/xs_wire.h>
 #include <public/io/console.h>

--- a/drivers/winpv/xenbus/include/xen/xen/errno.h
+++ b/drivers/winpv/xenbus/include/xen/xen/errno.h
@@ -3,7 +3,7 @@
 
 #ifndef __ASSEMBLY__
 
-#define XEN_ERRNO(name, value) WINPV_##name = value,
+#define XEN_ERRNO(name, value) name = value,
 enum {
 #include <public/errno.h>
 };

--- a/drivers/winpv/xenbus/vs2019/xen/xen.vcxproj
+++ b/drivers/winpv/xenbus/vs2019/xen/xen.vcxproj
@@ -21,7 +21,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>$(WindowsSdkDir)\include\km;..\..\include;..\..\include\xen;..\..\src\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_NO_CRT_STDIO_INLINE;PROJECT=$(ProjectName);POOL_NX_OPTIN=1;NT_PROCESSOR_GROUPS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>PROJECT=$(ProjectName);POOL_NX_OPTIN=1;NT_PROCESSOR_GROUPS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(XEN_REGISTER_BASED_ABI)'!=''">XEN_REGISTER_BASED_ABI;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <WarningLevel>EnableAllWarnings</WarningLevel>

--- a/drivers/winpv/xenbus/vs2019/xenbus/xenbus.vcxproj
+++ b/drivers/winpv/xenbus/vs2019/xenbus/xenbus.vcxproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>_NO_CRT_STDIO_INLINE;PROJECT=$(ProjectName);POOL_NX_OPTIN=1;NT_PROCESSOR_GROUPS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>PROJECT=$(ProjectName);POOL_NX_OPTIN=1;NT_PROCESSOR_GROUPS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <AdditionalIncludeDirectories>$(WindowsSdkDir)\include\km;..\..\include;..\..\include\xen;..\..\src\common;..\..\..\..\..\include;..\..\..\..\..\deps\hypervisor\bfsdk\include;</AdditionalIncludeDirectories>
       <WarningLevel>EnableAllWarnings</WarningLevel>

--- a/drivers/winpv/xeniface/src/xenagent/xenifacedevice.cpp
+++ b/drivers/winpv/xeniface/src/xenagent/xenifacedevice.cpp
@@ -152,7 +152,7 @@ bool CXenIfaceDevice::SuspendGetCount(DWORD *count)
 // sharedinfo interface
 bool CXenIfaceDevice::SharedInfoGetTime(FILETIME* time, bool* local)
 {
-    XENIFACE_SHAREDINFO_GET_TIME_OUT out = { NULL };
+    XENIFACE_SHAREDINFO_GET_TIME_OUT out {};
     if (!Ioctl(IOCTL_XENIFACE_SHAREDINFO_GET_TIME,
                NULL, 0,
                &out, sizeof(out)))

--- a/drivers/winpv/xeniface/vs2019/xeniface/xeniface.vcxproj
+++ b/drivers/winpv/xeniface/vs2019/xeniface/xeniface.vcxproj
@@ -21,7 +21,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>$(WindowsSdkDir)\include\km;..\..\include;</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_NO_CRT_STDIO_INLINE;PROJECT=$(ProjectName);POOL_NX_OPTIN=1;NT_PROCESSOR_GROUPS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>PROJECT=$(ProjectName);POOL_NX_OPTIN=1;NT_PROCESSOR_GROUPS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <WarningLevel>EnableAllWarnings</WarningLevel>
       <DisableSpecificWarnings>4464;4711;4548;4770;4820;4668;4255;5045;6001;6054;26451;28160;30030;30029;%(DisableSpecificWarnings)</DisableSpecificWarnings>

--- a/drivers/winpv/xennet/vs2019/xennet/xennet.vcxproj
+++ b/drivers/winpv/xennet/vs2019/xennet/xennet.vcxproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>_NO_CRT_STDIO_INLINE;PROJECT=$(ProjectName);NDIS_MINIPORT_DRIVER;NDIS_WDM=1;NDIS61_MINIPORT=1;POOL_NX_OPTIN=1;NT_PROCESSOR_GROUPS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>PROJECT=$(ProjectName);NDIS_MINIPORT_DRIVER;NDIS_WDM=1;NDIS61_MINIPORT=1;POOL_NX_OPTIN=1;NT_PROCESSOR_GROUPS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <AdditionalIncludeDirectories>$(WindowsSdkDir)\include\km;..\..\include;..\..\include\xen;</AdditionalIncludeDirectories>
       <WarningLevel>EnableAllWarnings</WarningLevel>

--- a/drivers/winpv/xenvif/include/xen-types.h
+++ b/drivers/winpv/xenvif/include/xen-types.h
@@ -46,9 +46,7 @@ typedef USHORT  uint16_t;
 typedef ULONG   uint32_t;
 typedef ULONG64 uint64_t;
 
-#ifndef offsetof
 #define offsetof(_type, _field) FIELD_OFFSET(_type, _field)
-#endif
 
 #define xen_mb()    KeMemoryBarrier()
 #define xen_wmb()   KeMemoryBarrier()

--- a/drivers/winpv/xenvif/vs2019/xenvif/xenvif.vcxproj
+++ b/drivers/winpv/xenvif/vs2019/xenvif/xenvif.vcxproj
@@ -21,7 +21,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>$(WindowsSdkDir)\include\km;..\..\include;..\..\include\xen;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_NO_CRT_STDIO_INLINE;PROJECT=$(ProjectName);POOL_NX_OPTIN=1;NT_PROCESSOR_GROUPS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>PROJECT=$(ProjectName);POOL_NX_OPTIN=1;NT_PROCESSOR_GROUPS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <WarningLevel>EnableAllWarnings</WarningLevel>
       <DisableSpecificWarnings>4464;4711;4770;4548;4820;4668;4255;5045;6001;6054;26451;28196;30030;30029;%(DisableSpecificWarnings)</DisableSpecificWarnings>


### PR DESCRIPTION
The Github Actions' Windows VM was updated automatically and the winpv drivers build is failing on the latest VS.
This fixes a couple of build errors allowing for the CI to pass again.