### PR TITLE
kvm_get_regs API

### DIFF
--- a/hypercall/include/c/mv_constants.h
+++ b/hypercall/include/c/mv_constants.h
@@ -470,5 +470,7 @@ mv_is_spec1_supported(uint32_t const version)
 #define MV_VPS_OP_XSAVE_GET_ALL_IDX_VAL ((uint64_t)0x0000000000000021)
 /** @brief Defines the index for mv_vps_op_xsave_set_all */
 #define MV_VPS_OP_XSAVE_SET_ALL_IDX_VAL ((uint64_t)0x0000000000000022)
+/** @brief Defines the index for MV_RDL_MAX_ENTRIES */
+#define MV_RDL_MAX_ENTRIES ((uint64_t)0x00000000000000FA)
 
 #endif

--- a/hypercall/include/c/x64/amd/mv_rdl_entry_t.h
+++ b/hypercall/include/c/x64/amd/mv_rdl_entry_t.h
@@ -1,0 +1,47 @@
+/// @copyright
+/// Copyright (C) 2020 Assured Information Security, Inc.
+///
+/// @copyright
+/// Permission is hereby granted, free of charge, to any person obtaining a copy
+/// of this software and associated documentation files (the "Software"), to deal
+/// in the Software without restriction, including without limitation the rights
+/// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+/// copies of the Software, and to permit persons to whom the Software is
+/// furnished to do so, subject to the following conditions:
+///
+/// @copyright
+/// The above copyright notice and this permission notice shall be included in
+/// all copies or substantial portions of the Software.
+///
+/// @copyright
+/// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+/// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+/// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+/// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+/// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+/// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+/// SOFTWARE.
+
+#ifndef MV_RDL_ENTRY_T_H
+#define MV_RDL_ENTRY_T_H
+
+#include <stdint.h>
+
+/**
+ * @struct mv_rdl_entry_t
+ *
+ * <!-- description -->
+ *   @brief see /include/uapi/linux/kvm.h in Linux for more details.
+ *   @var mv_rdl_entry_t::reg
+ *   Member reg holds An mv_reg_t or MSR index
+ *   @var mv_rdl_entry_t::val
+ *   Member val holds The value read or to be written
+*/
+
+struct mv_rdl_entry_t
+{
+    uint64_t reg;
+    uint64_t val;
+};
+
+#endif

--- a/hypercall/include/c/x64/amd/mv_rdl_t.h
+++ b/hypercall/include/c/x64/amd/mv_rdl_t.h
@@ -1,0 +1,82 @@
+/// @copyright
+/// Copyright (C) 2020 Assured Information Security, Inc.
+///
+/// @copyright
+/// Permission is hereby granted, free of charge, to any person obtaining a copy
+/// of this software and associated documentation files (the "Software"), to deal
+/// in the Software without restriction, including without limitation the rights
+/// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+/// copies of the Software, and to permit persons to whom the Software is
+/// furnished to do so, subject to the following conditions:
+///
+/// @copyright
+/// The above copyright notice and this permission notice shall be included in
+/// all copies or substantial portions of the Software.
+///
+/// @copyright
+/// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+/// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+/// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+/// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+/// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+/// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+/// SOFTWARE.
+
+#ifndef MV_RDL_T_H
+#define MV_RDL_T_H
+
+#include <mv_constants.h>
+#include <mv_rdl_entry_t.h>
+#include <stdint.h>
+
+/**
+ * @struct mv_rdl_t
+ *
+ * <!-- description -->
+ *   @brief see /include/uapi/linux/kvm.h in Linux for more details.
+ *   @var mv_rdl_t::reg0 
+ *   Member reg0 holds Registers which is ABI dependent. REVI if unused
+ *   @var mv_rdl_t::reg1
+ *   Member reg1 holds Registers which is ABI dependent. REVI if unused
+ *   @var mv_rdl_t::reg2
+ *   Member reg2 holds Registers which is ABI dependent. REVI if unused
+ *   @var mv_rdl_t::reg3
+ *   Member reg3 holds Registers which is ABI dependent. REVI if unused
+ *   @var mv_rdl_t::reg4
+ *   Member reg4 holds Registers which is ABI dependent. REVI if unused
+ *   @var mv_rdl_t::reg5
+ *   Member reg5 holds Registers which is ABI dependent. REVI if unused
+ *   @var mv_rdl_t::reg6
+ *   Member reg6 holds Registers which is ABI dependent. REVI if unused
+ *   @var mv_rdl_t::reg7
+ *   Member reg7 holds Registers which is ABI dependent. REVI if unused
+ *   @var mv_rdl_t::reserved1
+ *   Member reserved1 holds reserved for REVI
+ *   @var mv_rdl_t::reserved2
+ *   Member reserved2 holds reserved for REVI
+ *   @var mv_rdl_t::reserved3
+ *   Member reserved3 holds reserved for REVI
+ *   @var mv_rdl_t::num_entries
+ *   Member num_entries holds the number of entries in the RDL
+ *   @var mv_rdl_t::entries
+ *   Member entries holds Each entry in the RDL
+*/
+
+struct mv_rdl_t
+{
+    uint64_t reg0;
+    uint64_t reg1;
+    uint64_t reg2;
+    uint64_t reg3;
+    uint64_t reg4;
+    uint64_t reg5;
+    uint64_t reg6;
+    uint64_t reg7;
+    uint64_t reserved1;
+    uint64_t reserved2;
+    uint64_t reserved3;
+    uint64_t num_entries;
+    struct mv_rdl_entry_t entries[MV_RDL_MAX_ENTRIES];
+};
+
+#endif

--- a/hypercall/include/c/x64/amd/mv_reg_t.h
+++ b/hypercall/include/c/x64/amd/mv_reg_t.h
@@ -33,7 +33,25 @@
  */
 enum mv_reg_t
 {
-    mv_reg_t_dummy = 0
+    mv_reg_t_dummy = 0,
+    mv_reg_t_rax = 1,
+    mv_reg_t_rbx = 2,
+    mv_reg_t_rcx = 3,
+    mv_reg_t_rdx = 4,
+    mv_reg_t_rbp = 5,
+    mv_reg_t_rsi = 6,
+    mv_reg_t_rdi = 7,
+    mv_reg_t_r8 = 8,
+    mv_reg_t_r9 = 9,
+    mv_reg_t_r10 = 10,
+    mv_reg_t_r11 = 11,
+    mv_reg_t_r12 = 12,
+    mv_reg_t_r13 = 13,
+    mv_reg_t_r14 = 14,
+    mv_reg_t_r15 = 15,
+    mv_reg_t_rsp = 16,
+    mv_reg_t_rip = 17,
+    mv_reg_t_rflags = 18
 };
 
 #endif

--- a/shim/include/handle_vcpu_kvm_get_regs.h
+++ b/shim/include/handle_vcpu_kvm_get_regs.h
@@ -28,6 +28,7 @@
 #define HANDLE_VCPU_KVM_GET_REGS_H
 
 #include <kvm_regs.h>
+#include <shim_vcpu_t.h>
 #include <types.h>
 
 /**
@@ -38,6 +39,6 @@
  *   @param ioctl_args the arguments provided by userspace
  *   @return SHIM_SUCCESS on success, SHIM_FAILURE on failure.
  */
-int64_t handle_vcpu_kvm_get_regs(struct kvm_regs *const ioctl_args);
+int64_t handle_vcpu_kvm_get_regs(struct shim_vcpu_t const *const vcpu, struct kvm_regs *const regs);
 
 #endif

--- a/shim/include/kvm_regs.h
+++ b/shim/include/kvm_regs.h
@@ -36,9 +36,65 @@
  *
  * <!-- description -->
  *   @brief see /include/uapi/linux/kvm.h in Linux for more details.
+ *   @var kvm_regs::rax 
+ *   Member rax holds register value
+ *   @var kvm_regs::rbx
+ *   Member rbx holds register value
+ *   @var kvm_regs::rcx
+ *   Member rcx holds register value
+ *   @var kvm_regs::rdx
+ *   Member rdx holds register value
+ *   @var kvm_regs::rsi
+ *   Member rsi holds register value
+ *   @var kvm_regs::rdi
+ *   Member rdi holds register value
+ *   @var kvm_regs::rsp
+ *   Member rsp holds register value
+ *   @var kvm_regs::rbp
+ *   Member rbp holds register value
+ *   @var kvm_regs::r8
+ *   Member r8 holds register value
+ *   @var kvm_regs::r9
+ *   Member r9 holds register value
+ *   @var kvm_regs::r10
+ *   Member r10 holds register value
+ *   @var kvm_regs::r11
+ *   Member r11 holds register value
+ *   @var kvm_regs::r12
+ *   Member r12 holds register value
+ *   @var kvm_regs::r13
+ *   Member r13 holds register value
+ *   @var kvm_regs::r14
+ *   Member r14 holds register value
+ *   @var kvm_regs::r15
+ *   Member r15 holds register value
+ *   @var kvm_regs::rip
+ *   Member rip holds register value
+ *   @var kvm_regs::rflags
+ *   Member rflags holds register value
  */
+
 struct kvm_regs
-{};
+{
+    uint64_t rax;
+    uint64_t rbx;
+    uint64_t rcx;
+    uint64_t rdx;
+    uint64_t rsi;
+    uint64_t rdi;
+    uint64_t rsp;
+    uint64_t rbp;
+    uint64_t r8;
+    uint64_t r9;
+    uint64_t r10;
+    uint64_t r11;
+    uint64_t r12;
+    uint64_t r13;
+    uint64_t r14;
+    uint64_t r15;
+    uint64_t rip;
+    uint64_t rflags;
+};
 
 #pragma pack(pop)
 

--- a/shim/linux/Makefile
+++ b/shim/linux/Makefile
@@ -37,12 +37,14 @@ ifneq ($(KERNELRELEASE),)
     $(TARGET_MODULE)-objs += ../src/handle_system_kvm_create_vm.o
     $(TARGET_MODULE)-objs += ../src/handle_system_kvm_destroy_vm.o
     $(TARGET_MODULE)-objs += ../src/handle_vm_kvm_create_vcpu.o
+    $(TARGET_MODULE)-objs += ../src/handle_vcpu_kvm_get_regs.o
 	
 	EXTRA_CFLAGS += -I$(src)/include
 	EXTRA_CFLAGS += -I$(src)/include/std
 	EXTRA_CFLAGS += -I$(src)/include/platform_interface
 	EXTRA_CFLAGS += -I$(src)/../include
 	EXTRA_CFLAGS += -I$(src)/../../hypercall/include/c
+	EXTRA_CFLAGS += -I$(src)/../../hypercall/include/c/x64/amd
 	EXTRA_CFLAGS += -I$(src)/../../hypercall/src/c
 	EXTRA_CFLAGS += -I$(CMAKE_BINARY_DIR)/include
 

--- a/shim/src/handle_vcpu_kvm_get_regs.c
+++ b/shim/src/handle_vcpu_kvm_get_regs.c
@@ -26,19 +26,134 @@
 
 #include <debug.h>
 #include <kvm_regs.h>
+#include <mv_rdl_entry_t.h>
+#include <mv_rdl_t.h>
+#include <mv_reg_t.h>
+#include <platform.h>
+#include <shim_vcpu_t.h>
 #include <types.h>
+
+/* Remove me */
+#define HYPERVISOR_PAGE_SIZE 13
+#define HYPERVISOR_MAX_PPS 10
+
+/* Remove me */
+/**
+ * @struct page_t
+ *
+ * <!-- description -->
+ *   @brief see /include/uapi/linux/kvm.h in Linux for more details.
+ *   @var page_t::data
+ *   Member reg holds data 
+*/
+
+struct page_t
+{
+    uint8_t data[HYPERVISOR_PAGE_SIZE];
+};
+
+/* Remove me */
+struct page_t g_shared_pages[HYPERVISOR_MAX_PPS] = {0};
+
+/* Remove me */
+uint32_t
+platform_current_cpu(void)
+{
+    return 10;
+}
+
+/* Remove me */
+void *
+shared_page_for_this_pp(void)
+{
+    uint32_t ppid = platform_current_cpu();
+    platform_expects(ppid < HYPERVISOR_MAX_PPS);
+
+    return &g_shared_pages[ppid];
+}
+
+/* Remove me */
+uint16_t
+ms_vs_op_reg_get_list(uint64_t const vsid)
+{
+    return 1;
+}
 
 /**
  * <!-- description -->
  *   @brief Handles the execution of kvm_get_regs.
  *
  * <!-- inputs/outputs -->
- *   @param ioctl_args the arguments provided by userspace
+ *   @param vcpu paramter to extract the vsid
+ *   @param regs the arguments provided by userspace
  *   @return SHIM_SUCCESS on success, SHIM_FAILURE on failure.
  */
 int64_t
-handle_vcpu_kvm_get_regs(struct kvm_regs *const ioctl_args)
+handle_vcpu_kvm_get_regs(struct shim_vcpu_t const *const vcpu, struct kvm_regs *const regs)
 {
-    (void)ioctl_args;
+    const int RAX_IDX = 0;
+    const int RBX_IDX = 1;
+    const int RCX_IDX = 2;
+    const int RDX_IDX = 3;
+    const int RSI_IDX = 4;
+    const int RDI_IDX = 5;
+    const int RBP_IDX = 6;
+    const int R8_IDX = 7;
+    const int R9_IDX = 8;
+    const int R10_IDX = 9;
+    const int R11_IDX = 10;
+    const int R12_IDX = 11;
+    const int R13_IDX = 12;
+    const int R14_IDX = 13;
+    const int R15_IDX = 14;
+    const int RSP_IDX = 15;
+    const int RIP_IDX = 16;
+    const int RFLAGS_IDX = 17;
+
+    struct mv_rdl_t *const rdl = (struct mv_rdl_t *const)shared_page_for_this_pp();
+
+    rdl->entries[RAX_IDX].reg = mv_reg_t_rax;
+    rdl->entries[RBX_IDX].reg = mv_reg_t_rbx;
+    rdl->entries[RCX_IDX].reg = mv_reg_t_rcx;
+    rdl->entries[RDX_IDX].reg = mv_reg_t_rdx;
+    rdl->entries[RSI_IDX].reg = mv_reg_t_rsi;
+    rdl->entries[RDI_IDX].reg = mv_reg_t_rdi;
+    rdl->entries[RBP_IDX].reg = mv_reg_t_rbp;
+    rdl->entries[R8_IDX].reg = mv_reg_t_r8;
+    rdl->entries[R9_IDX].reg = mv_reg_t_r9;
+    rdl->entries[R10_IDX].reg = mv_reg_t_r10;
+    rdl->entries[R11_IDX].reg = mv_reg_t_r11;
+    rdl->entries[R12_IDX].reg = mv_reg_t_r12;
+    rdl->entries[R13_IDX].reg = mv_reg_t_r13;
+    rdl->entries[R14_IDX].reg = mv_reg_t_r14;
+    rdl->entries[R15_IDX].reg = mv_reg_t_r15;
+    rdl->entries[RSP_IDX].reg = mv_reg_t_rsp;
+    rdl->entries[RIP_IDX].reg = mv_reg_t_rip;
+    rdl->entries[RFLAGS_IDX].reg = mv_reg_t_rflags;
+
+    if (ms_vs_op_reg_get_list(vcpu->vsid)) {
+        bferror("ms_vs_op_reg_get_list failed");
+        return SHIM_FAILURE;
+    }
+
+    regs->rax = rdl->entries[RAX_IDX].val;
+    regs->rbx = rdl->entries[RBX_IDX].val;
+    regs->rcx = rdl->entries[RCX_IDX].val;
+    regs->rdx = rdl->entries[RDX_IDX].val;
+    regs->rsi = rdl->entries[RSI_IDX].val;
+    regs->rdi = rdl->entries[RDI_IDX].val;
+    regs->rbp = rdl->entries[RBP_IDX].val;
+    regs->r8 = rdl->entries[R8_IDX].val;
+    regs->r9 = rdl->entries[R9_IDX].val;
+    regs->r10 = rdl->entries[R10_IDX].val;
+    regs->r11 = rdl->entries[R11_IDX].val;
+    regs->r12 = rdl->entries[R12_IDX].val;
+    regs->r13 = rdl->entries[R13_IDX].val;
+    regs->r14 = rdl->entries[R14_IDX].val;
+    regs->r15 = rdl->entries[R15_IDX].val;
+    regs->rsp = rdl->entries[RSP_IDX].val;
+    regs->rip = rdl->entries[RIP_IDX].val;
+    regs->rflags = rdl->entries[RFLAGS_IDX].val;
+
     return SHIM_SUCCESS;
 }


### PR DESCRIPTION
1) Added MV_RDL_MAX_ENTRIES  in hypercall/include/c/mv_constants.h
2) Added new file hypercall/include/c/x64/amd/mv_rdl_entry_t.h for struct mv_rdl_entry_t
3) Added new file hypercall/include/c/x64/amd/mv_rdl_t.h for struct mv_rdl_t
4) changed enum entries in hypercall/include/c/x64/amd/mv_reg_t.h as per Hypercall Specification documentation
5) changed the handle_vcpu_kvm_get_regs signature by added the first parameter of vcpu in handle_vcpu_kvm_get_regs.h 
6) changed kvm_regs structure in kvm_regs.h as per KVM API documentation
7) Modified the Makefile for obj's handle_vcpu_kvm_get_regs.o and include hypercall/include/c/x64/amd
8) Changed the dispatch_vcpu_kvm_get_regs function and reference signature  in entry.c
9) Implemented the  handle_vcpu_kvm_get_regs function in handle_vcpu_kvm_get_regs.c file 
