### PR TITLE
kvm get_regs API

### DIFF
--- a/hypercall/include/x64/mv_reg_t.h
+++ b/hypercall/include/x64/mv_reg_t.h
@@ -131,16 +131,16 @@ enum mv_reg_t
         /** @brief defines the gs_base register */
         mv_reg_t_gs_base = 42,
         /** @brief defines the ldtr_selector register */
-	// NOLINTNEXTLINE(bsl-identifier-typographically-unambiguous)
+        // NOLINTNEXTLINE(bsl-identifier-typographically-unambiguous)
         mv_reg_t_ldtr_selector = 43,
         /** @brief defines the ldtr_attrib register */
-	// NOLINTNEXTLINE(bsl-identifier-typographically-unambiguous)
+        // NOLINTNEXTLINE(bsl-identifier-typographically-unambiguous)
         mv_reg_t_ldtr_attrib = 44,
         /** @brief defines the ldtr_limit register */
-	// NOLINTNEXTLINE(bsl-identifier-typographically-unambiguous)
+        // NOLINTNEXTLINE(bsl-identifier-typographically-unambiguous)
         mv_reg_t_ldtr_limit = 45,
         /** @brief defines the ldtr_base register */
-	// NOLINTNEXTLINE(bsl-identifier-typographically-unambiguous)
+        // NOLINTNEXTLINE(bsl-identifier-typographically-unambiguous)
         mv_reg_t_ldtr_base = 46,
         /** @brief defines the tr_selector register */
         mv_reg_t_tr_selector = 47,
@@ -159,15 +159,16 @@ enum mv_reg_t
         /** @brief defines the gdtr_base register */
         mv_reg_t_gdtr_base = 54,
         /** @brief defines the idtr_selector register */
-	// NOLINTNEXTLINE(bsl-identifier-typographically-unambiguous)
+        // NOLINTNEXTLINE(bsl-identifier-typographically-unambiguous)
         mv_reg_t_idtr_selector = 55,
         /** @brief defines the idtr_attrib register */
-	// NOLINTNEXTLINE(bsl-identifier-typographically-unambiguous)
+        // NOLINTNEXTLINE(bsl-identifier-typographically-unambiguous)
         mv_reg_t_idtr_attrib = 56,
         /** @brief defines the idtr_limit register */
-	// NOLINTNEXTLINE(bsl-identifier-typographically-unambiguous)
+        // NOLINTNEXTLINE(bsl-identifier-typographically-unambiguous)
         mv_reg_t_idtr_limit = 57,
         /** @brief defines the idtr_base register */
+        // NOLINTNEXTLINE(bsl-identifier-typographically-unambiguous)
         mv_reg_t_idtr_base = 58,
         /** @brief defines the dr0 register */
         mv_reg_t_dr0 = 59,

--- a/hypercall/include/x64/mv_reg_t.h
+++ b/hypercall/include/x64/mv_reg_t.h
@@ -131,12 +131,16 @@ enum mv_reg_t
         /** @brief defines the gs_base register */
         mv_reg_t_gs_base = 42,
         /** @brief defines the ldtr_selector register */
+	// NOLINTNEXTLINE(bsl-identifier-typographically-unambiguous)
         mv_reg_t_ldtr_selector = 43,
         /** @brief defines the ldtr_attrib register */
+	// NOLINTNEXTLINE(bsl-identifier-typographically-unambiguous)
         mv_reg_t_ldtr_attrib = 44,
         /** @brief defines the ldtr_limit register */
+	// NOLINTNEXTLINE(bsl-identifier-typographically-unambiguous)
         mv_reg_t_ldtr_limit = 45,
         /** @brief defines the ldtr_base register */
+	// NOLINTNEXTLINE(bsl-identifier-typographically-unambiguous)
         mv_reg_t_ldtr_base = 46,
         /** @brief defines the tr_selector register */
         mv_reg_t_tr_selector = 47,
@@ -155,10 +159,13 @@ enum mv_reg_t
         /** @brief defines the gdtr_base register */
         mv_reg_t_gdtr_base = 54,
         /** @brief defines the idtr_selector register */
+	// NOLINTNEXTLINE(bsl-identifier-typographically-unambiguous)
         mv_reg_t_idtr_selector = 55,
         /** @brief defines the idtr_attrib register */
+	// NOLINTNEXTLINE(bsl-identifier-typographically-unambiguous)
         mv_reg_t_idtr_attrib = 56,
         /** @brief defines the idtr_limit register */
+	// NOLINTNEXTLINE(bsl-identifier-typographically-unambiguous)
         mv_reg_t_idtr_limit = 57,
         /** @brief defines the idtr_base register */
         mv_reg_t_idtr_base = 58,

--- a/shim/include/handle_vcpu_kvm_get_regs.h
+++ b/shim/include/handle_vcpu_kvm_get_regs.h
@@ -28,6 +28,7 @@
 #define HANDLE_VCPU_KVM_GET_REGS_H
 
 #include <kvm_regs.h>
+#include <shim_vcpu_t.h>
 #include <types.h>
 
 #ifdef __cplusplus
@@ -43,7 +44,8 @@ extern "C"
      *   @param pmut_ioctl_args the arguments provided by userspace
      *   @return SHIM_SUCCESS on success, SHIM_FAILURE on failure.
      */
-    NODISCARD int64_t handle_vcpu_kvm_get_regs(struct kvm_regs *const pmut_ioctl_args) NOEXCEPT;
+    NODISCARD int64_t handle_vcpu_kvm_get_regs(
+        struct shim_vcpu_t const *const vcpu, struct kvm_regs *const pmut_ioctl_args) NOEXCEPT;
 
 #ifdef __cplusplus
 }

--- a/shim/include/handle_vcpu_kvm_get_regs.h
+++ b/shim/include/handle_vcpu_kvm_get_regs.h
@@ -41,12 +41,12 @@ extern "C"
      *   @brief Handles the execution of kvm_get_regs.
      *
      * <!-- inputs/outputs -->
-     *   @param vcpu to get vsid to pass to hypercall
+     *   @param pmut_vcpu to get vsid to pass to hypercall
      *   @param pmut_args the arguments provided by userspace
      *   @return SHIM_SUCCESS on success, SHIM_FAILURE on failure.
      */
     NODISCARD int64_t handle_vcpu_kvm_get_regs(
-        struct shim_vcpu_t const *const vcpu, struct kvm_regs *const pmut_args) NOEXCEPT;
+        struct shim_vcpu_t *const pmut_vcpu, struct kvm_regs *const pmut_args) NOEXCEPT;
 
 #ifdef __cplusplus
 }

--- a/shim/include/handle_vcpu_kvm_get_regs.h
+++ b/shim/include/handle_vcpu_kvm_get_regs.h
@@ -41,11 +41,12 @@ extern "C"
      *   @brief Handles the execution of kvm_get_regs.
      *
      * <!-- inputs/outputs -->
-     *   @param user_args the arguments provided by userspace
+     *   @param vcpu to get vsid to pass to hypercall
+     *   @param pmut_args the arguments provided by userspace
      *   @return SHIM_SUCCESS on success, SHIM_FAILURE on failure.
      */
     NODISCARD int64_t handle_vcpu_kvm_get_regs(
-        struct shim_vcpu_t const *const vcpu, struct kvm_regs *const user_args) NOEXCEPT;
+        struct shim_vcpu_t const *const vcpu, struct kvm_regs *const pmut_args) NOEXCEPT;
 
 #ifdef __cplusplus
 }

--- a/shim/include/handle_vcpu_kvm_get_regs.h
+++ b/shim/include/handle_vcpu_kvm_get_regs.h
@@ -41,11 +41,11 @@ extern "C"
      *   @brief Handles the execution of kvm_get_regs.
      *
      * <!-- inputs/outputs -->
-     *   @param pmut_ioctl_args the arguments provided by userspace
+     *   @param user_args the arguments provided by userspace
      *   @return SHIM_SUCCESS on success, SHIM_FAILURE on failure.
      */
     NODISCARD int64_t handle_vcpu_kvm_get_regs(
-        struct shim_vcpu_t const *const vcpu, struct kvm_regs *const pmut_ioctl_args) NOEXCEPT;
+        struct shim_vcpu_t const *const vcpu, struct kvm_regs *const user_args) NOEXCEPT;
 
 #ifdef __cplusplus
 }

--- a/shim/include/kvm_regs.h
+++ b/shim/include/kvm_regs.h
@@ -44,8 +44,42 @@ extern "C"
      */
     struct kvm_regs
     {
-        /** @brief replace me with contents from KVM API */
-        int32_t dummy;
+        /** @brief rax stores register value */
+        uint64_t rax;
+        /** @brief rbx stores register value */
+        uint64_t rbx;
+        /** @brief rcx stores register value */
+        uint64_t rcx;
+        /** @brief rdx stores register value */
+        uint64_t rdx;
+        /** @brief rsi stores register value */
+        uint64_t rsi;
+        /** @brief rdi stores register value */
+        uint64_t rdi;
+        /** @brief rsp stores register value */
+        uint64_t rsp;
+        /** @brief rbp stores register value */
+        uint64_t rbp;
+        /** @brief r8 stores register value */
+        uint64_t r8;
+        /** @brief r9 stores register value */
+        uint64_t r9;
+        /** @brief r10 stores register value */
+        uint64_t r10;
+        /** @brief r11 stores register value */
+        uint64_t r11;
+        /** @brief r12 stores register value */
+        uint64_t r12;
+        /** @brief r13 stores register value */
+        uint64_t r13;
+        /** @brief r14 stores register value */
+        uint64_t r14;
+        /** @brief r15 stores register value */
+        uint64_t r15;
+        /** @brief rip stores register value */
+        uint64_t rip;
+        /** @brief rflags stores register value */
+        uint64_t rflags;
     };
 
 #pragma pack(pop)

--- a/shim/include/kvm_regs.h
+++ b/shim/include/kvm_regs.h
@@ -44,41 +44,41 @@ extern "C"
      */
     struct kvm_regs
     {
-        /** @brief rax stores register value */
+        /** @brief stores that value of the rax register */
         uint64_t rax;
-        /** @brief rbx stores register value */
+        /** @brief stores that value of the rbx register */
         uint64_t rbx;
-        /** @brief rcx stores register value */
+        /** @brief stores that value of the rcx register */
         uint64_t rcx;
-        /** @brief rdx stores register value */
+        /** @brief stores that value of the rdx register */
         uint64_t rdx;
-        /** @brief rsi stores register value */
+        /** @brief stores that value of the rsi register */
         uint64_t rsi;
-        /** @brief rdi stores register value */
+        /** @brief stores that value of the rdi register */
         uint64_t rdi;
-        /** @brief rsp stores register value */
+        /** @brief stores that value of the rsp register */
         uint64_t rsp;
-        /** @brief rbp stores register value */
+        /** @brief stores that value of the rbp register */
         uint64_t rbp;
-        /** @brief r8 stores register value */
+        /** @brief stores that value of the r8 register */
         uint64_t r8;
-        /** @brief r9 stores register value */
+        /** @brief stores that value of the r9 register */
         uint64_t r9;
-        /** @brief r10 stores register value */
+        /** @brief stores that value of the r10 register */
         uint64_t r10;
-        /** @brief r11 stores register value */
+        /** @brief stores that value of the r11 register */
         uint64_t r11;
-        /** @brief r12 stores register value */
+        /** @brief stores that value of the r12 register */
         uint64_t r12;
-        /** @brief r13 stores register value */
+        /** @brief stores that value of the r13 register */
         uint64_t r13;
-        /** @brief r14 stores register value */
+        /** @brief stores that value of the r14 register */
         uint64_t r14;
-        /** @brief r15 stores register value */
+        /** @brief stores that value of the r15 register */
         uint64_t r15;
-        /** @brief rip stores register value */
+        /** @brief stores that value of the rip register */
         uint64_t rip;
-        /** @brief rflags stores register value */
+        /** @brief stores that value of the rflags register */
         uint64_t rflags;
     };
 

--- a/shim/include/kvm_regs_idxs.h
+++ b/shim/include/kvm_regs_idxs.h
@@ -1,0 +1,73 @@
+/**
+ * @copyright
+ * Copyright (C) 2020 Assured Information Security, Inc.
+ *
+ * @copyright
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * @copyright
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * @copyright
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef KVM_REGS_IDXS_H
+#define KVM_REGS_IDXS_H
+
+#include <stdint.h>
+
+#pragma pack(push, 1)
+
+/** @brief index for RAX register */
+#define RAX_IDX ((uint64_t)0)
+/** @brief index for RBX register */
+#define RBX_IDX ((uint64_t)1)
+/** @brief index for RCX register */
+#define RCX_IDX ((uint64_t)2)
+/** @brief index for RDX register */
+#define RDX_IDX ((uint64_t)3)
+/** @brief index for RSI register */
+#define RSI_IDX ((uint64_t)4)
+/** @brief index for RDI register */
+#define RDI_IDX ((uint64_t)5)
+/** @brief index for RBP register */
+#define RBP_IDX ((uint64_t)6)
+/** @brief index for R8 register */
+#define R8_IDX ((uint64_t)7)
+/** @brief index for R9 register */
+#define R9_IDX ((uint64_t)8)
+/** @brief index for R10 register */
+#define R10_IDX ((uint64_t)9)
+/** @brief index for R11 register */
+#define R11_IDX ((uint64_t)10)
+/** @brief index for R12 register */
+#define R12_IDX ((uint64_t)11)
+/** @brief index for R13 register */
+#define R13_IDX ((uint64_t)12)
+/** @brief index for R14 register */
+#define R14_IDX ((uint64_t)13)
+/** @brief index for R15 register */
+#define R15_IDX ((uint64_t)14)
+/** @brief index for RSP register */
+#define RSP_IDX ((uint64_t)15)
+/** @brief index for RIP register */
+#define RIP_IDX ((uint64_t)16)
+/** @brief index for RFLAGS register */
+#define RFLAGS_IDX ((uint64_t)17)
+
+#pragma pack(pop)
+
+#endif

--- a/shim/include/kvm_regs_idxs.h
+++ b/shim/include/kvm_regs_idxs.h
@@ -29,7 +29,10 @@
 
 #include <stdint.h>
 
-#pragma pack(push, 1)
+#ifdef __cplusplus
+extern "C"
+{
+#endif
 
 /** @brief index for RAX register */
 #define RAX_IDX ((uint64_t)0)
@@ -68,6 +71,11 @@
 /** @brief index for RFLAGS register */
 #define RFLAGS_IDX ((uint64_t)17)
 
-#pragma pack(pop)
+/** @brief stores the total number of entries for rdl */
+#define TOTAL_NUM_ENTRIES ((uint64_t)18)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/shim/linux/Makefile
+++ b/shim/linux/Makefile
@@ -132,6 +132,7 @@ ifneq ($(KERNELRELEASE),)
 	EXTRA_CFLAGS += -I$(src)/include/platform_interface
 	EXTRA_CFLAGS += -I$(src)/../include
 	EXTRA_CFLAGS += -I$(src)/../../hypercall/include
+	EXTRA_CFLAGS += -I$(src)/../../hypercall/include/x64
 	EXTRA_CFLAGS += -I$(src)/../../hypercall/src
 	EXTRA_CFLAGS += -I$(CMAKE_BINARY_DIR)/include
 

--- a/shim/linux/src/entry.c
+++ b/shim/linux/src/entry.c
@@ -828,21 +828,16 @@ dispatch_vcpu_kvm_get_one_reg(struct kvm_one_reg *const ioctl_args)
 
 static long
 dispatch_vcpu_kvm_get_regs(
-    struct shim_vcpu_t const *const pmut_vcpu,
-    struct kvm_regs *const pmut_ioctl_args)
+    struct shim_vcpu_t const *const vcpu, struct kvm_regs *const user_args)
 {
     struct kvm_regs mut_args;
 
-    if (handle_vcpu_kvm_get_regs(pmut_vcpu, &mut_args)) {
+    if (handle_vcpu_kvm_get_regs(vcpu, &mut_args)) {
         bferror("handle_vcpu_kvm_get_regs failed");
         return -EINVAL;
     }
 
-    platform_copy_to_user(pmut_ioctl_args, &mut_args, sizeof(struct kvm_regs));
-    if (NULL == pmut_ioctl_args) {
-        bferror("platform_copy_to_user failed");
-        return -EINVAL;
-    }
+    platform_copy_to_user(user_args, &mut_args, sizeof(struct kvm_regs));
 
     return (long)1;
 }

--- a/shim/linux/src/entry.c
+++ b/shim/linux/src/entry.c
@@ -30,6 +30,7 @@
 #include <handle_system_kvm_create_vm.h>
 #include <handle_system_kvm_destroy_vm.h>
 #include <handle_system_kvm_get_vcpu_mmap_size.h>
+#include <handle_vcpu_kvm_get_regs.h>
 #include <handle_vm_kvm_create_vcpu.h>
 #include <handle_vm_kvm_destroy_vcpu.h>
 #include <linux/anon_inodes.h>
@@ -826,10 +827,24 @@ dispatch_vcpu_kvm_get_one_reg(struct kvm_one_reg *const ioctl_args)
 }
 
 static long
-dispatch_vcpu_kvm_get_regs(struct kvm_regs *const ioctl_args)
+dispatch_vcpu_kvm_get_regs(
+    struct shim_vcpu_t const *const pmut_vcpu,
+    struct kvm_regs *const pmut_ioctl_args)
 {
-    (void)ioctl_args;
-    return -EINVAL;
+    struct kvm_regs mut_args;
+
+    if (handle_vcpu_kvm_get_regs(pmut_vcpu, &mut_args)) {
+        bferror("handle_vcpu_kvm_get_regs failed");
+        return -EINVAL;
+    }
+
+    platform_copy_to_user(pmut_ioctl_args, &mut_args, sizeof(struct kvm_regs));
+    if (NULL == pmut_ioctl_args) {
+        bferror("platform_copy_to_user failed");
+        return -EINVAL;
+    }
+
+    return (long)1;
 }
 
 static long
@@ -1085,7 +1100,8 @@ dev_unlocked_ioctl_vcpu(
         }
 
         case KVM_GET_REGS: {
-            return dispatch_vcpu_kvm_get_regs((struct kvm_regs *)ioctl_args);
+            return dispatch_vcpu_kvm_get_regs(
+                pmut_mut_vcpu, (struct kvm_regs *)ioctl_args);
         }
 
         case KVM_GET_SREGS: {

--- a/shim/src/handle_vcpu_kvm_get_regs.c
+++ b/shim/src/handle_vcpu_kvm_get_regs.c
@@ -24,8 +24,20 @@
  * SOFTWARE.
  */
 
+#include <debug.h>
+#include <g_mut_hndl.h>
 #include <kvm_regs.h>
+#include <kvm_regs_idxs.h>
+#include <mv_hypercall.h>
+#include <mv_rdl_entry_t.h>
+#include <mv_rdl_t.h>
+#include <mv_reg_t.h>
+#include <platform.h>
+#include <shim_vcpu_t.h>
 #include <types.h>
+
+/** @brief stores the total number of entries for rdl */
+#define TOTAL_NUM_ENTRIES ((uint64_t)18)
 
 /**
  * <!-- description -->
@@ -36,8 +48,57 @@
  *   @return SHIM_SUCCESS on success, SHIM_FAILURE on failure.
  */
 NODISCARD int64_t
-handle_vcpu_kvm_get_regs(struct kvm_regs *const pmut_ioctl_args) NOEXCEPT
+handle_vcpu_kvm_get_regs(
+    struct shim_vcpu_t const *const pmut_vcpu, struct kvm_regs *const pmut_ioctl_args) NOEXCEPT
 {
-    (void)pmut_ioctl_args;
+
+    struct mv_rdl_t *const pmut_rdl = (struct mv_rdl_t *const)shared_page_for_current_pp();
+    platform_expects(NULL != pmut_rdl);
+    platform_expects(MV_INVALID_HANDLE != g_mut_hndl);
+
+    pmut_rdl->entries[RAX_IDX].reg = mv_reg_t_rax;
+    pmut_rdl->entries[RBX_IDX].reg = mv_reg_t_rbx;
+    pmut_rdl->entries[RCX_IDX].reg = mv_reg_t_rcx;
+    pmut_rdl->entries[RDX_IDX].reg = mv_reg_t_rdx;
+    pmut_rdl->entries[RSI_IDX].reg = mv_reg_t_rsi;
+    pmut_rdl->entries[RDI_IDX].reg = mv_reg_t_rdi;
+    pmut_rdl->entries[RBP_IDX].reg = mv_reg_t_rbp;
+    pmut_rdl->entries[R8_IDX].reg = mv_reg_t_r8;
+    pmut_rdl->entries[R9_IDX].reg = mv_reg_t_r9;
+    pmut_rdl->entries[R10_IDX].reg = mv_reg_t_r10;
+    pmut_rdl->entries[R11_IDX].reg = mv_reg_t_r11;
+    pmut_rdl->entries[R12_IDX].reg = mv_reg_t_r12;
+    pmut_rdl->entries[R13_IDX].reg = mv_reg_t_r13;
+    pmut_rdl->entries[R14_IDX].reg = mv_reg_t_r14;
+    pmut_rdl->entries[R15_IDX].reg = mv_reg_t_r15;
+    pmut_rdl->entries[RSP_IDX].reg = mv_reg_t_rsp;
+    pmut_rdl->entries[RIP_IDX].reg = mv_reg_t_rip;
+    pmut_rdl->entries[RFLAGS_IDX].reg = mv_reg_t_rflags;
+    pmut_rdl->num_entries = TOTAL_NUM_ENTRIES;
+
+    if (mv_vs_op_reg_get_list(g_mut_hndl, pmut_vcpu->vsid)) {
+        bferror("ms_vs_op_reg_get_list failed");
+        return SHIM_FAILURE;
+    }
+
+    pmut_ioctl_args->rax = pmut_rdl->entries[RAX_IDX].val;
+    pmut_ioctl_args->rbx = pmut_rdl->entries[RBX_IDX].val;
+    pmut_ioctl_args->rcx = pmut_rdl->entries[RCX_IDX].val;
+    pmut_ioctl_args->rdx = pmut_rdl->entries[RDX_IDX].val;
+    pmut_ioctl_args->rsi = pmut_rdl->entries[RSI_IDX].val;
+    pmut_ioctl_args->rdi = pmut_rdl->entries[RDI_IDX].val;
+    pmut_ioctl_args->rbp = pmut_rdl->entries[RBP_IDX].val;
+    pmut_ioctl_args->r8 = pmut_rdl->entries[R8_IDX].val;
+    pmut_ioctl_args->r9 = pmut_rdl->entries[R9_IDX].val;
+    pmut_ioctl_args->r10 = pmut_rdl->entries[R10_IDX].val;
+    pmut_ioctl_args->r11 = pmut_rdl->entries[R11_IDX].val;
+    pmut_ioctl_args->r12 = pmut_rdl->entries[R12_IDX].val;
+    pmut_ioctl_args->r13 = pmut_rdl->entries[R13_IDX].val;
+    pmut_ioctl_args->r14 = pmut_rdl->entries[R14_IDX].val;
+    pmut_ioctl_args->r15 = pmut_rdl->entries[R15_IDX].val;
+    pmut_ioctl_args->rsp = pmut_rdl->entries[RSP_IDX].val;
+    pmut_ioctl_args->rip = pmut_rdl->entries[RIP_IDX].val;
+    pmut_ioctl_args->rflags = pmut_rdl->entries[RFLAGS_IDX].val;
+
     return SHIM_SUCCESS;
 }

--- a/shim/src/handle_vcpu_kvm_get_regs.c
+++ b/shim/src/handle_vcpu_kvm_get_regs.c
@@ -33,28 +33,28 @@
 #include <mv_rdl_t.h>
 #include <mv_reg_t.h>
 #include <platform.h>
+#include <shared_page_for_current_pp.h>
 #include <shim_vcpu_t.h>
 #include <types.h>
-
-/** @brief stores the total number of entries for rdl */
-#define TOTAL_NUM_ENTRIES ((uint64_t)18)
 
 /**
  * <!-- description -->
  *   @brief Handles the execution of kvm_get_regs.
  *
  * <!-- inputs/outputs -->
- *   @param pmut_ioctl_args the arguments provided by userspace
+ *   @param pmut_vcpu arguments received from private data	
+ *   @param pmut_args the arguments provided by userspace
  *   @return SHIM_SUCCESS on success, SHIM_FAILURE on failure.
  */
 NODISCARD int64_t
 handle_vcpu_kvm_get_regs(
-    struct shim_vcpu_t const *const pmut_vcpu, struct kvm_regs *const pmut_ioctl_args) NOEXCEPT
+    struct shim_vcpu_t const *const pmut_vcpu, struct kvm_regs *const pmut_args) NOEXCEPT
 {
+
+    platform_expects(MV_INVALID_HANDLE != g_mut_hndl);
 
     struct mv_rdl_t *const pmut_rdl = (struct mv_rdl_t *const)shared_page_for_current_pp();
     platform_expects(NULL != pmut_rdl);
-    platform_expects(MV_INVALID_HANDLE != g_mut_hndl);
 
     pmut_rdl->entries[RAX_IDX].reg = mv_reg_t_rax;
     pmut_rdl->entries[RBX_IDX].reg = mv_reg_t_rbx;
@@ -81,24 +81,24 @@ handle_vcpu_kvm_get_regs(
         return SHIM_FAILURE;
     }
 
-    pmut_ioctl_args->rax = pmut_rdl->entries[RAX_IDX].val;
-    pmut_ioctl_args->rbx = pmut_rdl->entries[RBX_IDX].val;
-    pmut_ioctl_args->rcx = pmut_rdl->entries[RCX_IDX].val;
-    pmut_ioctl_args->rdx = pmut_rdl->entries[RDX_IDX].val;
-    pmut_ioctl_args->rsi = pmut_rdl->entries[RSI_IDX].val;
-    pmut_ioctl_args->rdi = pmut_rdl->entries[RDI_IDX].val;
-    pmut_ioctl_args->rbp = pmut_rdl->entries[RBP_IDX].val;
-    pmut_ioctl_args->r8 = pmut_rdl->entries[R8_IDX].val;
-    pmut_ioctl_args->r9 = pmut_rdl->entries[R9_IDX].val;
-    pmut_ioctl_args->r10 = pmut_rdl->entries[R10_IDX].val;
-    pmut_ioctl_args->r11 = pmut_rdl->entries[R11_IDX].val;
-    pmut_ioctl_args->r12 = pmut_rdl->entries[R12_IDX].val;
-    pmut_ioctl_args->r13 = pmut_rdl->entries[R13_IDX].val;
-    pmut_ioctl_args->r14 = pmut_rdl->entries[R14_IDX].val;
-    pmut_ioctl_args->r15 = pmut_rdl->entries[R15_IDX].val;
-    pmut_ioctl_args->rsp = pmut_rdl->entries[RSP_IDX].val;
-    pmut_ioctl_args->rip = pmut_rdl->entries[RIP_IDX].val;
-    pmut_ioctl_args->rflags = pmut_rdl->entries[RFLAGS_IDX].val;
+    pmut_args->rax = pmut_rdl->entries[RAX_IDX].val;
+    pmut_args->rbx = pmut_rdl->entries[RBX_IDX].val;
+    pmut_args->rcx = pmut_rdl->entries[RCX_IDX].val;
+    pmut_args->rdx = pmut_rdl->entries[RDX_IDX].val;
+    pmut_args->rsi = pmut_rdl->entries[RSI_IDX].val;
+    pmut_args->rdi = pmut_rdl->entries[RDI_IDX].val;
+    pmut_args->rbp = pmut_rdl->entries[RBP_IDX].val;
+    pmut_args->r8 = pmut_rdl->entries[R8_IDX].val;
+    pmut_args->r9 = pmut_rdl->entries[R9_IDX].val;
+    pmut_args->r10 = pmut_rdl->entries[R10_IDX].val;
+    pmut_args->r11 = pmut_rdl->entries[R11_IDX].val;
+    pmut_args->r12 = pmut_rdl->entries[R12_IDX].val;
+    pmut_args->r13 = pmut_rdl->entries[R13_IDX].val;
+    pmut_args->r14 = pmut_rdl->entries[R14_IDX].val;
+    pmut_args->r15 = pmut_rdl->entries[R15_IDX].val;
+    pmut_args->rsp = pmut_rdl->entries[RSP_IDX].val;
+    pmut_args->rip = pmut_rdl->entries[RIP_IDX].val;
+    pmut_args->rflags = pmut_rdl->entries[RFLAGS_IDX].val;
 
     return SHIM_SUCCESS;
 }

--- a/shim/src/handle_vcpu_kvm_get_regs.c
+++ b/shim/src/handle_vcpu_kvm_get_regs.c
@@ -42,13 +42,14 @@
  *   @brief Handles the execution of kvm_get_regs.
  *
  * <!-- inputs/outputs -->
- *   @param pmut_cst_vcpu arguments received from private data	
+ *   @param pmut_vcpu arguments received from private data	
  *   @param pmut_args the arguments provided by userspace
  *   @return SHIM_SUCCESS on success, SHIM_FAILURE on failure.
  */
 NODISCARD int64_t
 handle_vcpu_kvm_get_regs(
-    struct shim_vcpu_t const *const pmut_cst_vcpu, struct kvm_regs *const pmut_args) NOEXCEPT
+    struct shim_vcpu_t *const pmut_vcpu, struct kvm_regs *const pmut_args) NOEXCEPT
+
 {
 
     platform_expects(MV_INVALID_HANDLE != g_mut_hndl);
@@ -76,7 +77,7 @@ handle_vcpu_kvm_get_regs(
     pmut_rdl->entries[RFLAGS_IDX].reg = (uint64_t)mv_reg_t_rflags;
     pmut_rdl->num_entries = TOTAL_NUM_ENTRIES;
 
-    if (mv_vs_op_reg_get_list(g_mut_hndl, pmut_cst_vcpu->vsid)) {
+    if (mv_vs_op_reg_get_list(g_mut_hndl, pmut_vcpu->vsid)) {
         bferror("ms_vs_op_reg_get_list failed");
         return SHIM_FAILURE;
     }

--- a/shim/src/handle_vcpu_kvm_get_regs.c
+++ b/shim/src/handle_vcpu_kvm_get_regs.c
@@ -28,8 +28,8 @@
 #include <g_mut_hndl.h>
 #include <kvm_regs.h>
 #include <kvm_regs_idxs.h>
+#include <mv_constants.h>
 #include <mv_hypercall.h>
-#include <mv_rdl_entry_t.h>
 #include <mv_rdl_t.h>
 #include <mv_reg_t.h>
 #include <platform.h>
@@ -42,13 +42,13 @@
  *   @brief Handles the execution of kvm_get_regs.
  *
  * <!-- inputs/outputs -->
- *   @param mut_vcpu arguments received from private data	
+ *   @param pmut_cst_vcpu arguments received from private data	
  *   @param pmut_args the arguments provided by userspace
  *   @return SHIM_SUCCESS on success, SHIM_FAILURE on failure.
  */
 NODISCARD int64_t
 handle_vcpu_kvm_get_regs(
-    struct shim_vcpu_t const *const mut_vcpu, struct kvm_regs *const pmut_args) NOEXCEPT
+    struct shim_vcpu_t const *const pmut_cst_vcpu, struct kvm_regs *const pmut_args) NOEXCEPT
 {
 
     platform_expects(MV_INVALID_HANDLE != g_mut_hndl);
@@ -76,7 +76,7 @@ handle_vcpu_kvm_get_regs(
     pmut_rdl->entries[RFLAGS_IDX].reg = (uint64_t)mv_reg_t_rflags;
     pmut_rdl->num_entries = TOTAL_NUM_ENTRIES;
 
-    if (mv_vs_op_reg_get_list(g_mut_hndl, mut_vcpu->vsid)) {
+    if (mv_vs_op_reg_get_list(g_mut_hndl, pmut_cst_vcpu->vsid)) {
         bferror("ms_vs_op_reg_get_list failed");
         return SHIM_FAILURE;
     }

--- a/shim/src/handle_vcpu_kvm_get_regs.c
+++ b/shim/src/handle_vcpu_kvm_get_regs.c
@@ -42,13 +42,13 @@
  *   @brief Handles the execution of kvm_get_regs.
  *
  * <!-- inputs/outputs -->
- *   @param pmut_vcpu arguments received from private data	
+ *   @param mut_vcpu arguments received from private data	
  *   @param pmut_args the arguments provided by userspace
  *   @return SHIM_SUCCESS on success, SHIM_FAILURE on failure.
  */
 NODISCARD int64_t
 handle_vcpu_kvm_get_regs(
-    struct shim_vcpu_t const *const pmut_vcpu, struct kvm_regs *const pmut_args) NOEXCEPT
+    struct shim_vcpu_t const *const mut_vcpu, struct kvm_regs *const pmut_args) NOEXCEPT
 {
 
     platform_expects(MV_INVALID_HANDLE != g_mut_hndl);
@@ -56,27 +56,27 @@ handle_vcpu_kvm_get_regs(
     struct mv_rdl_t *const pmut_rdl = (struct mv_rdl_t *const)shared_page_for_current_pp();
     platform_expects(NULL != pmut_rdl);
 
-    pmut_rdl->entries[RAX_IDX].reg = mv_reg_t_rax;
-    pmut_rdl->entries[RBX_IDX].reg = mv_reg_t_rbx;
-    pmut_rdl->entries[RCX_IDX].reg = mv_reg_t_rcx;
-    pmut_rdl->entries[RDX_IDX].reg = mv_reg_t_rdx;
-    pmut_rdl->entries[RSI_IDX].reg = mv_reg_t_rsi;
-    pmut_rdl->entries[RDI_IDX].reg = mv_reg_t_rdi;
-    pmut_rdl->entries[RBP_IDX].reg = mv_reg_t_rbp;
-    pmut_rdl->entries[R8_IDX].reg = mv_reg_t_r8;
-    pmut_rdl->entries[R9_IDX].reg = mv_reg_t_r9;
-    pmut_rdl->entries[R10_IDX].reg = mv_reg_t_r10;
-    pmut_rdl->entries[R11_IDX].reg = mv_reg_t_r11;
-    pmut_rdl->entries[R12_IDX].reg = mv_reg_t_r12;
-    pmut_rdl->entries[R13_IDX].reg = mv_reg_t_r13;
-    pmut_rdl->entries[R14_IDX].reg = mv_reg_t_r14;
-    pmut_rdl->entries[R15_IDX].reg = mv_reg_t_r15;
-    pmut_rdl->entries[RSP_IDX].reg = mv_reg_t_rsp;
-    pmut_rdl->entries[RIP_IDX].reg = mv_reg_t_rip;
-    pmut_rdl->entries[RFLAGS_IDX].reg = mv_reg_t_rflags;
+    pmut_rdl->entries[RAX_IDX].reg = (uint64_t)mv_reg_t_rax;
+    pmut_rdl->entries[RBX_IDX].reg = (uint64_t)mv_reg_t_rbx;
+    pmut_rdl->entries[RCX_IDX].reg = (uint64_t)mv_reg_t_rcx;
+    pmut_rdl->entries[RDX_IDX].reg = (uint64_t)mv_reg_t_rdx;
+    pmut_rdl->entries[RSI_IDX].reg = (uint64_t)mv_reg_t_rsi;
+    pmut_rdl->entries[RDI_IDX].reg = (uint64_t)mv_reg_t_rdi;
+    pmut_rdl->entries[RBP_IDX].reg = (uint64_t)mv_reg_t_rbp;
+    pmut_rdl->entries[R8_IDX].reg = (uint64_t)mv_reg_t_r8;
+    pmut_rdl->entries[R9_IDX].reg = (uint64_t)mv_reg_t_r9;
+    pmut_rdl->entries[R10_IDX].reg = (uint64_t)mv_reg_t_r10;
+    pmut_rdl->entries[R11_IDX].reg = (uint64_t)mv_reg_t_r11;
+    pmut_rdl->entries[R12_IDX].reg = (uint64_t)mv_reg_t_r12;
+    pmut_rdl->entries[R13_IDX].reg = (uint64_t)mv_reg_t_r13;
+    pmut_rdl->entries[R14_IDX].reg = (uint64_t)mv_reg_t_r14;
+    pmut_rdl->entries[R15_IDX].reg = (uint64_t)mv_reg_t_r15;
+    pmut_rdl->entries[RSP_IDX].reg = (uint64_t)mv_reg_t_rsp;
+    pmut_rdl->entries[RIP_IDX].reg = (uint64_t)mv_reg_t_rip;
+    pmut_rdl->entries[RFLAGS_IDX].reg = (uint64_t)mv_reg_t_rflags;
     pmut_rdl->num_entries = TOTAL_NUM_ENTRIES;
 
-    if (mv_vs_op_reg_get_list(g_mut_hndl, pmut_vcpu->vsid)) {
+    if (mv_vs_op_reg_get_list(g_mut_hndl, mut_vcpu->vsid)) {
         bferror("ms_vs_op_reg_get_list failed");
         return SHIM_FAILURE;
     }

--- a/shim/tests/CMakeLists.txt
+++ b/shim/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ list(APPEND COMMON_INCLUDES
     ${CMAKE_CURRENT_LIST_DIR}/include
     ${CMAKE_CURRENT_LIST_DIR}/src
     ${CMAKE_SOURCE_DIR}/hypercall/include
+    ${CMAKE_SOURCE_DIR}/hypercall/include/x64
     ${CMAKE_SOURCE_DIR}/hypercall/mocks
 )
 

--- a/shim/tests/include/helpers.hpp
+++ b/shim/tests/include/helpers.hpp
@@ -72,6 +72,8 @@ namespace shim
         constinit mv_status_t g_mut_mv_vs_op_reg_get_list{};    // NOLINT
         constinit mv_status_t g_mut_mv_vs_op_reg_set_list{};    // NOLINT
 
+        constinit bsl::uint64 g_mut_rdl_entry_val{};    //NOLINT
+
         extern bsl::int32 g_mut_platform_alloc_fails;
         extern bsl::uint32 g_mut_platform_num_online_cpus;
     }

--- a/shim/tests/src/test_handle_vcpu_kvm_get_regs.cpp
+++ b/shim/tests/src/test_handle_vcpu_kvm_get_regs.cpp
@@ -24,9 +24,10 @@
 
 #include "../../include/handle_vcpu_kvm_get_regs.h"
 
-#include <kvm_regs.h>
-#include <types.h>
+#include <helpers.hpp>
 
+#include <bsl/convert.hpp>
+#include <bsl/safe_integral.hpp>
 #include <bsl/ut.hpp>
 
 namespace shim
@@ -43,18 +44,54 @@ namespace shim
     [[nodiscard]] constexpr auto
     tests() noexcept -> bsl::exit_code
     {
-        bsl::ut_scenario{"description"} = []() noexcept {
+        init_tests();
+        bsl::ut_scenario{"success"} = []() noexcept {
             bsl::ut_given{} = [&]() noexcept {
+                shim_vcpu_t mut_vcpu{};
+                kvm_regs mut_args{};
+                constexpr auto entryval{42_u64};
+                bsl::ut_when{} = [&]() noexcept {
+                    g_mut_rdl_entry_val = entryval.get();
+                    bsl::ut_then{} = [&]() noexcept {
+                        bsl::ut_check(
+                            SHIM_SUCCESS == handle_vcpu_kvm_get_regs(&mut_vcpu, &mut_args));
+                        bsl::ut_check(entryval == mut_args.rax);
+                        bsl::ut_check(entryval == mut_args.rbx);
+                        bsl::ut_check(entryval == mut_args.rcx);
+                        bsl::ut_check(entryval == mut_args.rdx);
+                        bsl::ut_check(entryval == mut_args.rsi);
+                        bsl::ut_check(entryval == mut_args.rdi);
+                        bsl::ut_check(entryval == mut_args.rsp);
+                        bsl::ut_check(entryval == mut_args.rbp);
+                        bsl::ut_check(entryval == mut_args.r8);
+                        bsl::ut_check(entryval == mut_args.r9);
+                        bsl::ut_check(entryval == mut_args.r10);
+                        bsl::ut_check(entryval == mut_args.r11);
+                        bsl::ut_check(entryval == mut_args.r12);
+                        bsl::ut_check(entryval == mut_args.r13);
+                        bsl::ut_check(entryval == mut_args.r14);
+                        bsl::ut_check(entryval == mut_args.r15);
+                        bsl::ut_check(entryval == mut_args.rip);
+                        bsl::ut_check(entryval == mut_args.rflags);
+                    };
+                };
+            };
+        };
+        bsl::ut_scenario{"mv_vs_op_reg_get_list fails"} = []() noexcept {
+            bsl::ut_given{} = [&]() noexcept {
+                shim_vcpu_t mut_vcpu{};
                 kvm_regs mut_args{};
                 bsl::ut_when{} = [&]() noexcept {
+                    g_mut_mv_vs_op_reg_get_list = MV_INVALID_ID;
                     bsl::ut_then{} = [&]() noexcept {
-                        bsl::ut_check(SHIM_SUCCESS == handle_vcpu_kvm_get_regs(&mut_args));
+                        bsl::ut_check(
+                            SHIM_FAILURE == handle_vcpu_kvm_get_regs(&mut_vcpu, &mut_args));
                     };
                 };
             };
         };
 
-        return bsl::ut_success();
+        return fini_tests();
     }
 }
 

--- a/shim/tests/src/test_handle_vcpu_kvm_get_regs.cpp
+++ b/shim/tests/src/test_handle_vcpu_kvm_get_regs.cpp
@@ -25,6 +25,7 @@
 #include "../../include/handle_vcpu_kvm_get_regs.h"
 
 #include <helpers.hpp>
+#include <kvm_regs.h>
 
 #include <bsl/convert.hpp>
 #include <bsl/safe_integral.hpp>


### PR DESCRIPTION
Following are the changes to merge into master

1) updated the signature by added new parameter in handle_vcpu_kvm_get_regs.h
2) updated registers in shim/include/kvm_regs.h as per KVM API's
3) created new file register indexs .. shim/include/kvm_regs_idxs.h 
4) updated the shim/linux/Makefile by adding hypercall/include/x64
5) updated dispatch_vcpu_kvm_get_regs function in shim/linux/src/entry.c
6) updated handle_vcpu_kvm_get_regs function in shim/src/handle_vcpu_kvm_get_regs.c
7) added reference g_mut_rdl_entry_val in shim/tests/include/helpers.hpp
8) Added unittests cases for get_regs in shim/tests/src/test_handle_vcpu_kvm_get_regs.cpp