### PR TITLE
kvm set_regs API

### DIFF
--- a/shim/include/handle_vcpu_kvm_set_regs.h
+++ b/shim/include/handle_vcpu_kvm_set_regs.h
@@ -28,6 +28,7 @@
 #define HANDLE_VCPU_KVM_SET_REGS_H
 
 #include <kvm_regs.h>
+#include <shim_vcpu_t.h>
 #include <types.h>
 
 #ifdef __cplusplus
@@ -40,10 +41,12 @@ extern "C"
      *   @brief Handles the execution of kvm_set_regs.
      *
      * <!-- inputs/outputs -->
-     *   @param pmut_ioctl_args the arguments provided by userspace
+     *   @param pmut_vcpu to get vsid value to pass to hypercall	
+     *   @param pmut_args the arguments provided by userspace
      *   @return SHIM_SUCCESS on success, SHIM_FAILURE on failure.
      */
-    NODISCARD int64_t handle_vcpu_kvm_set_regs(struct kvm_regs *const pmut_ioctl_args) NOEXCEPT;
+    NODISCARD int64_t handle_vcpu_kvm_set_regs(
+        struct shim_vcpu_t *const pmut_vcpu, struct kvm_regs *const pmut_args) NOEXCEPT;
 
 #ifdef __cplusplus
 }

--- a/shim/src/handle_vcpu_kvm_set_regs.c
+++ b/shim/src/handle_vcpu_kvm_set_regs.c
@@ -24,7 +24,17 @@
  * SOFTWARE.
  */
 
+#include <debug.h>
+#include <g_mut_hndl.h>
 #include <kvm_regs.h>
+#include <kvm_regs_idxs.h>
+#include <mv_constants.h>
+#include <mv_hypercall.h>
+#include <mv_rdl_t.h>
+#include <mv_reg_t.h>
+#include <platform.h>
+#include <shared_page_for_current_pp.h>
+#include <shim_vcpu_t.h>
 #include <types.h>
 
 /**
@@ -32,12 +42,62 @@
  *   @brief Handles the execution of kvm_set_regs.
  *
  * <!-- inputs/outputs -->
- *   @param pmut_ioctl_args the arguments provided by userspace
+ *   @param pmut_vcpu to pass vsid to microv 
+ *   @param pmut_args the arguments provided by userspace
  *   @return SHIM_SUCCESS on success, SHIM_FAILURE on failure.
  */
 NODISCARD int64_t
-handle_vcpu_kvm_set_regs(struct kvm_regs *const pmut_ioctl_args) NOEXCEPT
+handle_vcpu_kvm_set_regs(
+    struct shim_vcpu_t *const pmut_vcpu, struct kvm_regs *const pmut_args) NOEXCEPT
 {
-    (void)pmut_ioctl_args;
+    platform_expects(MV_INVALID_HANDLE != g_mut_hndl);
+
+    struct mv_rdl_t *const pmut_rdl = (struct mv_rdl_t *const)shared_page_for_current_pp();
+    platform_expects(NULL != pmut_rdl);
+
+    pmut_rdl->entries[RAX_IDX].reg = (uint64_t)mv_reg_t_rax;
+    pmut_rdl->entries[RBX_IDX].reg = (uint64_t)mv_reg_t_rbx;
+    pmut_rdl->entries[RCX_IDX].reg = (uint64_t)mv_reg_t_rcx;
+    pmut_rdl->entries[RDX_IDX].reg = (uint64_t)mv_reg_t_rdx;
+    pmut_rdl->entries[RSI_IDX].reg = (uint64_t)mv_reg_t_rsi;
+    pmut_rdl->entries[RDI_IDX].reg = (uint64_t)mv_reg_t_rdi;
+    pmut_rdl->entries[RBP_IDX].reg = (uint64_t)mv_reg_t_rbp;
+    pmut_rdl->entries[R8_IDX].reg = (uint64_t)mv_reg_t_r8;
+    pmut_rdl->entries[R9_IDX].reg = (uint64_t)mv_reg_t_r9;
+    pmut_rdl->entries[R10_IDX].reg = (uint64_t)mv_reg_t_r10;
+    pmut_rdl->entries[R11_IDX].reg = (uint64_t)mv_reg_t_r11;
+    pmut_rdl->entries[R12_IDX].reg = (uint64_t)mv_reg_t_r12;
+    pmut_rdl->entries[R13_IDX].reg = (uint64_t)mv_reg_t_r13;
+    pmut_rdl->entries[R14_IDX].reg = (uint64_t)mv_reg_t_r14;
+    pmut_rdl->entries[R15_IDX].reg = (uint64_t)mv_reg_t_r15;
+    pmut_rdl->entries[RSP_IDX].reg = (uint64_t)mv_reg_t_rsp;
+    pmut_rdl->entries[RIP_IDX].reg = (uint64_t)mv_reg_t_rip;
+    pmut_rdl->entries[RFLAGS_IDX].reg = (uint64_t)mv_reg_t_rflags;
+    pmut_rdl->num_entries = TOTAL_NUM_ENTRIES;
+
+    pmut_rdl->entries[RAX_IDX].val = pmut_args->rax;
+    pmut_rdl->entries[RBX_IDX].val = pmut_args->rbx;
+    pmut_rdl->entries[RCX_IDX].val = pmut_args->rcx;
+    pmut_rdl->entries[RDX_IDX].val = pmut_args->rdx;
+    pmut_rdl->entries[RSI_IDX].val = pmut_args->rsi;
+    pmut_rdl->entries[RDI_IDX].val = pmut_args->rdi;
+    pmut_rdl->entries[RBP_IDX].val = pmut_args->rbp;
+    pmut_rdl->entries[R8_IDX].val = pmut_args->r8;
+    pmut_rdl->entries[R9_IDX].val = pmut_args->r9;
+    pmut_rdl->entries[R10_IDX].val = pmut_args->r10;
+    pmut_rdl->entries[R11_IDX].val = pmut_args->r11;
+    pmut_rdl->entries[R12_IDX].val = pmut_args->r12;
+    pmut_rdl->entries[R13_IDX].val = pmut_args->r13;
+    pmut_rdl->entries[R14_IDX].val = pmut_args->r14;
+    pmut_rdl->entries[R15_IDX].val = pmut_args->r15;
+    pmut_rdl->entries[RSP_IDX].val = pmut_args->rsp;
+    pmut_rdl->entries[RIP_IDX].val = pmut_args->rip;
+    pmut_rdl->entries[RFLAGS_IDX].val = pmut_args->rflags;
+
+    if (mv_vs_op_reg_set_list(g_mut_hndl, pmut_vcpu->vsid)) {
+        bferror("mv_vs_op_reg_set_list failed");
+        return SHIM_FAILURE;
+    }
+
     return SHIM_SUCCESS;
 }

--- a/shim/tests/src/test_handle_vcpu_kvm_set_regs.cpp
+++ b/shim/tests/src/test_handle_vcpu_kvm_set_regs.cpp
@@ -24,9 +24,10 @@
 
 #include "../../include/handle_vcpu_kvm_set_regs.h"
 
-#include <kvm_regs.h>
-#include <types.h>
+#include <helpers.hpp>
 
+#include <bsl/convert.hpp>
+#include <bsl/safe_integral.hpp>
 #include <bsl/ut.hpp>
 
 namespace shim
@@ -43,18 +44,55 @@ namespace shim
     [[nodiscard]] constexpr auto
     tests() noexcept -> bsl::exit_code
     {
-        bsl::ut_scenario{"description"} = []() noexcept {
+        init_tests();
+        bsl::ut_scenario{"success"} = []() noexcept {
             bsl::ut_given{} = [&]() noexcept {
+                shim_vcpu_t mut_vcpu{};
                 kvm_regs mut_args{};
+                constexpr auto val{42_u64};
                 bsl::ut_when{} = [&]() noexcept {
+                    mut_args.rax = val.get();
+                    mut_args.rbx = val.get();
+                    mut_args.rcx = val.get();
+                    mut_args.rdx = val.get();
+                    mut_args.rsi = val.get();
+                    mut_args.rdi = val.get();
+                    mut_args.rsp = val.get();
+                    mut_args.rbp = val.get();
+                    mut_args.r8 = val.get();
+                    mut_args.r9 = val.get();
+                    mut_args.r10 = val.get();
+                    mut_args.r11 = val.get();
+                    mut_args.r12 = val.get();
+                    mut_args.r13 = val.get();
+                    mut_args.r14 = val.get();
+                    mut_args.r15 = val.get();
+                    mut_args.rip = val.get();
+                    mut_args.rflags = val.get();
                     bsl::ut_then{} = [&]() noexcept {
-                        bsl::ut_check(SHIM_SUCCESS == handle_vcpu_kvm_set_regs(&mut_args));
+                        bsl::ut_check(
+                            SHIM_SUCCESS == handle_vcpu_kvm_set_regs(&mut_vcpu, &mut_args));
                     };
                 };
             };
         };
 
-        return bsl::ut_success();
+        bsl::ut_scenario{"mv_vs_op_reg_set_list fails"} = []() noexcept {
+            bsl::ut_given{} = [&]() noexcept {
+                shim_vcpu_t mut_vcpu{};
+                kvm_regs mut_args{};
+                constexpr auto val{1_u64};
+                bsl::ut_when{} = [&]() noexcept {
+                    g_mut_mv_vs_op_reg_set_list = val.get();
+                    bsl::ut_then{} = [&]() noexcept {
+                        bsl::ut_check(
+                            SHIM_FAILURE == handle_vcpu_kvm_set_regs(&mut_vcpu, &mut_args));
+                    };
+                };
+            };
+        };
+
+        return fini_tests();
     }
 }
 

--- a/shim/tests/src/test_handle_vcpu_kvm_set_regs.cpp
+++ b/shim/tests/src/test_handle_vcpu_kvm_set_regs.cpp
@@ -25,6 +25,7 @@
 #include "../../include/handle_vcpu_kvm_set_regs.h"
 
 #include <helpers.hpp>
+#include <kvm_regs.h>
 
 #include <bsl/convert.hpp>
 #include <bsl/safe_integral.hpp>


### PR DESCRIPTION
Below is the list of changes for kvm set_regs API:

1)changed the signature of  handle_vcpu_kvm_set_regs function in shim/include/handle_vcpu_kvm_set_regs.h
2) implemented dispatch for set_regs function in  shim/linux/src/entry.c
3) implemented handle_vcpu_kvm_set_regs function in shim/src/handle_vcpu_kvm_set_regs.c
4) Added unit testcases for set_regs in shim/tests/src/test_handle_vcpu_kvm_set_regs.cpp