### PR TITLE
Shim: Add ioctl support for KVM_SET_USER_MEMORY_REGION

### DIFF
--- a/hypercall/include/mv_constants.h
+++ b/hypercall/include/mv_constants.h
@@ -91,33 +91,33 @@ extern "C"
 /* -------------------------------------------------------------------------- */
 
 /** @brief Indicates the map has read access */
-#define MV_MAP_FLAG_READ_ACCESS ((uint64_t)0x0000000000000001);
+#define MV_MAP_FLAG_READ_ACCESS ((uint64_t)0x0000000000000001)
 /** @brief Indicates the map has write access */
-#define MV_MAP_FLAG_WRITE_ACCESS ((uint64_t)0x0000000000000002);
+#define MV_MAP_FLAG_WRITE_ACCESS ((uint64_t)0x0000000000000002)
 /** @brief Indicates the map has execute access */
-#define MV_MAP_FLAG_EXECUTE_ACCESS ((uint64_t)0x0000000000000004);
+#define MV_MAP_FLAG_EXECUTE_ACCESS ((uint64_t)0x0000000000000004)
 /** @brief Indicates the map has user privileges */
-#define MV_MAP_FLAG_USER ((uint64_t)0x0000000000000008);
+#define MV_MAP_FLAG_USER ((uint64_t)0x0000000000000008)
 /** @brief Indicates the map is 4k in size */
-#define MV_MAP_FLAG_4K_PAGE ((uint64_t)0x0000000000000200);
+#define MV_MAP_FLAG_4K_PAGE ((uint64_t)0x0000000000000200)
 /** @brief Indicates the map is 2m in size */
-#define MV_MAP_FLAG_2M_PAGE ((uint64_t)0x0000000000000400);
+#define MV_MAP_FLAG_2M_PAGE ((uint64_t)0x0000000000000400)
 /** @brief Indicates the map is 1g in size */
-#define MV_MAP_FLAG_1G_PAGE ((uint64_t)0x0000000000000800);
+#define MV_MAP_FLAG_1G_PAGE ((uint64_t)0x0000000000000800)
 /** @brief Indicates the map is mapped as UC */
-#define MV_MAP_FLAG_UNCACHEABLE ((uint64_t)0x0200000000000000);
+#define MV_MAP_FLAG_UNCACHEABLE ((uint64_t)0x0200000000000000)
 /** @brief Indicates the map is mapped as UC- */
-#define MV_MAP_FLAG_UNCACHEABLE_MINUS ((uint64_t)0x0400000000000000);
+#define MV_MAP_FLAG_UNCACHEABLE_MINUS ((uint64_t)0x0400000000000000)
 /** @brief Indicates the map is mapped as WC */
-#define MV_MAP_FLAG_WRITE_COMBINING ((uint64_t)0x0800000000000000);
+#define MV_MAP_FLAG_WRITE_COMBINING ((uint64_t)0x0800000000000000)
 /** @brief Indicates the map is mapped as WC +*/
-#define MV_MAP_FLAG_WRITE_COMBINING_PLUS ((uint64_t)0x1000000000000000);
+#define MV_MAP_FLAG_WRITE_COMBINING_PLUS ((uint64_t)0x1000000000000000)
 /** @brief Indicates the map is mapped as WT */
-#define MV_MAP_FLAG_WRITE_THROUGH ((uint64_t)0x2000000000000000);
+#define MV_MAP_FLAG_WRITE_THROUGH ((uint64_t)0x2000000000000000)
 /** @brief Indicates the map is mapped as WB */
-#define MV_MAP_FLAG_WRITE_BACK ((uint64_t)0x4000000000000000);
+#define MV_MAP_FLAG_WRITE_BACK ((uint64_t)0x4000000000000000)
 /** @brief Indicates the map is mapped as WP */
-#define MV_MAP_FLAG_WRITE_PROTECTED ((uint64_t)0x8000000000000000);
+#define MV_MAP_FLAG_WRITE_PROTECTED ((uint64_t)0x8000000000000000)
 
 /* -------------------------------------------------------------------------- */
 /* Special IDs                                                                */

--- a/shim/include/handle_vm_kvm_set_user_memory_region.h
+++ b/shim/include/handle_vm_kvm_set_user_memory_region.h
@@ -40,11 +40,12 @@ extern "C"
      *   @brief Handles the execution of kvm_set_user_memory_region.
      *
      * <!-- inputs/outputs -->
-     *   @param pmut_ioctl_args the arguments provided by userspace
+     *   @param shim_vm the shim_vm_t argument
+     *   @param args the arguments provided by userspace
      *   @return SHIM_SUCCESS on success, SHIM_FAILURE on failure.
      */
     NODISCARD int64_t handle_vm_kvm_set_user_memory_region(
-        struct kvm_userspace_memory_region *const pmut_ioctl_args) NOEXCEPT;
+        struct shim_vm_t *shim_vm, struct kvm_userspace_memory_region *const args) NOEXCEPT;
 
 #ifdef __cplusplus
 }

--- a/shim/include/kvm_slot_t.h
+++ b/shim/include/kvm_slot_t.h
@@ -24,39 +24,40 @@
  * SOFTWARE.
  */
 
-#ifndef KVM_USERSPACE_MEMORY_REGION_H
-#define KVM_USERSPACE_MEMORY_REGION_H
+#ifndef KVM_SLOT_T_H
+#define KVM_SLOT_T_H
 
 #include <stdint.h>
+
+#define KVM_MEM_SLOTS_NUM 0x7FFF
+#define KVM_USER_MEM_SLOTS 0x7FFF
+// KVM_ADDRESS_SPACE_NUM needs some attention: defined as 1 in linux/hvm_host.h, 2 in asm/kvm_host.h
+#define KVM_ADDRESS_SPACE_NUM 1
 
 #ifdef __cplusplus
 extern "C"
 {
 #endif
 
-#pragma pack(push, 1)
-
     /**
-     * @struct kvm_userspace_memory_region
-     *
      * <!-- description -->
-     *   @brief see /include/uapi/linux/kvm.h in Linux for more details.
+     *   @brief An internal representation of a kvm slot for book keeping
      */
-    struct kvm_userspace_memory_region
+    struct kvm_slot_t
     {
-        /** @brief the guest physical memory slot */
-        uint32_t slot;
-        /** @brief the flags for this slot (log dirty pages or mem readonly) */
-        uint32_t flags;
-        /** @brief the guest physical address */
-        uint64_t guest_phys_addr;
-        /** @brief the memory size in bytes */
-        uint64_t memory_size;
-        /** @brief the start of the userspace allocated memory */
+        /** @brief stores the id of this slot */
+        int16_t id;
+        /** @brief stores the address space id that this slot is a member of */
+        uint16_t as_id;
+        /** @brief stores the base of the guest frame number */
+        uint64_t base_gfn;
+        /** @brief stores the number of pages */
+        uint32_t npages;
+        /** @brief stores the userspace address */
         uint64_t userspace_addr;
+        /** @brief stores the kvm flags for this slot */
+        uint64_t flags;
     };
-
-#pragma pack(pop)
 
 #ifdef __cplusplus
 }

--- a/shim/include/platform.h
+++ b/shim/include/platform.h
@@ -135,6 +135,20 @@ extern "C"
 
     /**
      * <!-- description -->
+     *   @brief Pins the pages within a memory region starting at "pmut_ptr" and
+     *     continuing for "num" bytes. Once pinned, the memory is guaranteed to
+     *     never be paged out to disk.
+     *
+     * <!-- inputs/outputs -->
+     *   @param pmut_ptr a pointer to the memory to pin
+     *   @param num the number of bytes to pin.
+     *   @return This function returns 0 on success, otherwise
+     *     this function returns a non-0 value
+     */
+    int64_t platform_mempin(void *const pmut_ptr, uint64_t const num) NOEXCEPT;
+
+    /**
+     * <!-- description -->
      *   @brief Copies "num" bytes from "src" to "pmut_dst". If "src" or "pmut_dst" are
      *     ((void *)0), returns SHIM_FAILURE, otherwise returns 0. Note that this function can
      *     be used to copy memory from userspace via an IOCTL.

--- a/shim/include/platform.h
+++ b/shim/include/platform.h
@@ -224,13 +224,24 @@ typedef uint64_t platform_mutex;
 
     /**
      * <!-- description -->
-     *   @brief Initializes a mutex lock. This must be called before a
-     *     mutex can be used.
+     *   @brief Initializes a mutex object. This must be called before a
+     *     mutex can be used and platform_mutex_destroy must be called to free
+     *     resources once the mutex has run through its lifestime.
      *
      * <!-- inputs/outputs -->
-     *   @param pmut_mutex the mutex to lock
+     *   @param pmut_mutex the mutex to initialize
      */
     void platform_mutex_init(platform_mutex *const pmut_mutex) NOEXCEPT;
+
+    /**
+     * <!-- description -->
+     *   @brief Destroys a mutex object. This must be called to free resources
+     *     allocated from platform_mutex_init.
+     *
+     * <!-- inputs/outputs -->
+     *   @param pmut_mutex the mutex to destroy
+     */
+    void platform_mutex_destroy(platform_mutex *const pmut_mutex) NOEXCEPT;
 
     /**
      * <!-- description -->

--- a/shim/include/platform.h
+++ b/shim/include/platform.h
@@ -145,7 +145,7 @@ extern "C"
      *   @return This function returns 0 on success, otherwise
      *     this function returns a non-0 value
      */
-    int64_t platform_mempin(void *const pmut_ptr, uint64_t const num) NOEXCEPT;
+    NODISCARD int64_t platform_mempin(void *const pmut_ptr, uint64_t const num) NOEXCEPT;
 
     /**
      * <!-- description -->

--- a/shim/include/shim_vm_t.h
+++ b/shim/include/shim_vm_t.h
@@ -28,9 +28,9 @@
 #define SHIM_VM_T_H
 
 #include <constants.h>
+#include <kvm_slot_t.h>
 #include <platform.h>
 #include <shim_vcpu_t.h>
-#include <kvm_slot_t.h>
 #include <stdint.h>
 #include <types.h>
 

--- a/shim/include/shim_vm_t.h
+++ b/shim/include/shim_vm_t.h
@@ -30,6 +30,7 @@
 #include <constants.h>
 #include <platform.h>
 #include <shim_vcpu_t.h>
+#include <kvm_slot_t.h>
 #include <stdint.h>
 #include <types.h>
 
@@ -62,6 +63,15 @@ extern "C"
 
         /** @brief stores the VCPUs associated with this VM */
         struct shim_vcpu_t vcpus[MICROV_MAX_VCPUS];
+
+        /** @brief stores the mutex lock used to operate on slots */
+        platform_mutex slots_mutex;
+        /** @brief stores the number of slots used */
+        int16_t used_slots;
+        /** @brief stores an array of indexes allowing to retrieve a slot given a slot id */
+        int16_t slot_id_to_index[KVM_MEM_SLOTS_NUM];
+        /** @brief stores the memory slots associated with this VM */
+        struct kvm_slot_t slots[KVM_MEM_SLOTS_NUM];
     };
 
 #pragma pack(pop)

--- a/shim/linux/src/platform.c
+++ b/shim/linux/src/platform.c
@@ -399,6 +399,20 @@ platform_mutex_init(platform_mutex *const pmut_mutex)
 
 /**
  * <!-- description -->
+ *   @brief Destroys a mutex object. This must be called to free resources
+ *     allocated from platform_mutex_init.
+ *
+ * <!-- inputs/outputs -->
+ *   @param pmut_mutex the mutex to destroy
+ */
+void
+platform_mutex_destroy(platform_mutex *const pmut_mutex) NOEXCEPT;
+{
+    mutex_destroy(pmut_mutex);
+}
+
+/**
+ * <!-- description -->
  *   @brief Locks a mutex object. The mutex object must be initialized
  *     using platform_mutex_init before it is used.
  *

--- a/shim/linux/src/platform.c
+++ b/shim/linux/src/platform.c
@@ -428,8 +428,7 @@ platform_mutex_init(platform_mutex *const pmut_mutex)
  * <!-- inputs/outputs -->
  *   @param pmut_mutex the mutex to destroy
  */
-void
-platform_mutex_destroy(platform_mutex *const pmut_mutex) NOEXCEPT;
+void platform_mutex_destroy(platform_mutex *const pmut_mutex) NOEXCEPT;
 {
     mutex_destroy(pmut_mutex);
 }

--- a/shim/linux/src/platform.c
+++ b/shim/linux/src/platform.c
@@ -32,8 +32,10 @@
 #include <linux/mm.h>
 #include <linux/slab.h>
 #include <linux/smp.h>
+#include <linux/unistd.h>
 #include <linux/vmalloc.h>
 #include <platform.h>
+#include <sys/syscall.h>
 #include <types.h>
 #include <work_on_cpu_callback_args.h>
 
@@ -183,6 +185,27 @@ platform_memcpy(void *const pmut_dst, void const *const src, uint64_t const num)
     platform_expects(((void *)0) != src);
 
     memcpy(pmut_dst, src, num);
+}
+
+/**
+ * <!-- description -->
+ *   @brief Pins the pages within a memory region starting at "pmut_ptr" and
+ *     continuing for "num" bytes. Once pinned, the memory is guaranteed to
+ *     never be paged out to disk.
+ *
+ * <!-- inputs/outputs -->
+ *   @param pmut_ptr a pointer to the memory to pin
+ *   @param num the number of bytes to pin.
+ *   @return This function returns 0 on success, otherwise
+ *     this function returns a non-0 value
+ */
+int64_t
+platform_mempin(void *const pmut_ptr, uint64_t const num)
+{
+    platform_expects((pmut_ptr & 0x0000000000000FFF) == 0);
+    platform_expects((num & 0x0000000000000FFF) == 0);
+
+    return syscall(__NR_mlock, pmut_ptr, num) != 0);
 }
 
 /**

--- a/shim/src/handle_system_kvm_create_vm.c
+++ b/shim/src/handle_system_kvm_create_vm.c
@@ -47,6 +47,7 @@ handle_system_kvm_create_vm(struct shim_vm_t *const pmut_vm) NOEXCEPT
     platform_expects(NULL != pmut_vm);
 
     platform_memset(pmut_vm, ((uint8_t)0), sizeof(struct shim_vm_t));
+    platform_mutex_init(&pmut_vm->mutex);
 
     pmut_vm->vmid = mv_vm_op_create_vm(g_mut_hndl);
     if (MV_INVALID_ID == (int32_t)pmut_vm->vmid) {

--- a/shim/src/handle_system_kvm_create_vm.c
+++ b/shim/src/handle_system_kvm_create_vm.c
@@ -49,6 +49,9 @@ handle_system_kvm_create_vm(struct shim_vm_t *const pmut_vm) NOEXCEPT
     platform_memset(pmut_vm, ((uint8_t)0), sizeof(struct shim_vm_t));
     platform_mutex_init(&pmut_vm->mutex);
 
+    platform_memset(pmut_vm->slot_id_to_index, ((uint8_t)-1), sizeof(struct shim_vm_t));
+    platform_mutex_init(&pmut_vm->slots_mutex);
+
     pmut_vm->vmid = mv_vm_op_create_vm(g_mut_hndl);
     if (MV_INVALID_ID == (int32_t)pmut_vm->vmid) {
         bferror("mv_vm_op_create_vm failed");

--- a/shim/src/handle_system_kvm_destroy_vm.c
+++ b/shim/src/handle_system_kvm_destroy_vm.c
@@ -44,5 +44,7 @@ handle_system_kvm_destroy_vm(struct shim_vm_t *const pmut_vm) NOEXCEPT
     platform_expects(MV_INVALID_HANDLE != g_mut_hndl);
     platform_expects(NULL != pmut_vm);
 
+    platform_mutex_destroy(&pmut_vm->mutex);
+
     platform_expects(MV_STATUS_SUCCESS == mv_vm_op_destroy_vm(g_mut_hndl, pmut_vm->vmid));
 }

--- a/shim/src/handle_vm_kvm_set_user_memory_region.c
+++ b/shim/src/handle_vm_kvm_set_user_memory_region.c
@@ -24,7 +24,16 @@
  * SOFTWARE.
  */
 
+#include <debug.h>
+#include <errno.h>
+#include <g_mut_hndl.h>
 #include <kvm_userspace_memory_region.h>
+#include <mv_constants.h>
+#include <mv_hypercall.h>
+#include <mv_mdl_t.h>
+#include <platform.h>
+#include <shared_page_for_current_pp.h>
+#include <shim_vm_t.h>
 #include <types.h>
 
 /**
@@ -32,13 +41,132 @@
  *   @brief Handles the execution of kvm_set_user_memory_region.
  *
  * <!-- inputs/outputs -->
- *   @param pmut_ioctl_args the arguments provided by userspace
+ *   @param shim_vm the shim_vm_t argument
+ *   @param args the arguments provided by userspace
  *   @return SHIM_SUCCESS on success, SHIM_FAILURE on failure.
  */
 NODISCARD int64_t
 handle_vm_kvm_set_user_memory_region(
-    struct kvm_userspace_memory_region *const pmut_ioctl_args) NOEXCEPT
+    struct shim_vm_t *const shim_vm, struct kvm_userspace_memory_region *const args) NOEXCEPT
 {
-    (void)pmut_ioctl_args;
+    int64_t ret = 0ULL;
+    uint64_t i = 0ULL;
+    struct mv_mdl_t *mdl = (struct mv_mdl_t *)shared_page_for_current_pp();
+    const uint16_t slot_id = (uint16_t)args->slot;
+    int16_t *slot_idx = &shim_vm->slot_id_to_index[slot_id];
+    struct kvm_slot_t *kslot;
+    const uint16_t as_id = args->slot >> 16;
+    const uint64_t addr = args->userspace_addr;
+    const uint64_t gpa = args->guest_phys_addr;
+    const uint64_t size = args->memory_size;
+    const uint32_t kvm_flags = args->flags;
+    uint64_t mv_flags =
+        MV_MAP_FLAG_READ_ACCESS | MV_MAP_FLAG_WRITE_ACCESS | MV_MAP_FLAG_EXECUTE_ACCESS;
+
+    platform_expects(!shim_vm);
+    platform_expects(!args);
+
+    if (size & 0x0000000000000FFFULL) {
+        bferror("memory_size is not alligned\n");
+        return SHIM_FAILURE;
+    }
+    if (gpa & 0x0000000000000FFFULL) {
+        bferror("guest_phys_addr is not alligned\n");
+        return SHIM_FAILURE;
+    }
+    if (addr & 0x0000000000000FFF) {
+        bferror("userspace_addr is not alligned\n");
+        return SHIM_FAILURE;
+    }
+    if (!addr) {
+        bferror("userspace_addr cannot be 0\n");
+        return SHIM_FAILURE;
+    }
+    if (args->slot >= KVM_USER_MEM_SLOTS) {
+        bferror("slot is out of bound\n");
+        return SHIM_FAILURE;
+    }
+    if (as_id >= KVM_ADDRESS_SPACE_NUM) {
+        bferror("slot is out of bound\n");
+        return SHIM_FAILURE;
+    }
+
+    platform_mutex_lock(&shim_vm->mutex);
+
+    if (*slot_idx < 0) {
+        // Create slot
+        *slot_idx = shim_vm->used_slots++;
+        kslot = &shim_vm->slots[*slot_idx];
+
+        kslot->id = (int16_t) slot_id;
+        kslot->as_id = as_id;
+        kslot->base_gfn = gpa >> 12ULL;
+        kslot->npages = (uint32_t) (size >> 12ULL);
+        kslot->userspace_addr = addr;
+        kslot->flags = kvm_flags;
+    }
+    else if (size == 0) {
+        // Delete slot
+        --shim_vm->used_slots;
+        kslot = &shim_vm->slots[*slot_idx];
+        *slot_idx = -1;
+        // TODO sanitize args with existing slot or just use existing slot?
+        i = kslot->npages * HYPERVISOR_PAGE_SIZE;
+        goto undo_mmio_map;
+
+    } else {
+        // Update or move slot
+        bferror("Updating or moving a slot is not yet implemented\n");
+        goto unlock;
+    }
+
+    if ((ret = platform_mempin((void *)addr, size))) {
+        goto unlock;
+    }
+
+    for (; i < size; i += HYPERVISOR_PAGE_SIZE) {
+        mdl->entries[mdl->num_entries].dst = gpa + i;
+        mdl->entries[mdl->num_entries].src = platform_virt_to_phys((void *)(addr + i));
+        mdl->entries[mdl->num_entries].bytes = HYPERVISOR_PAGE_SIZE;
+        mdl->entries[mdl->num_entries].flags = mv_flags;    // TODO: KVM to MicroV flags
+
+        if (mdl->num_entries >= MV_MDL_MAX_ENTRIES) {
+            if (mv_vm_op_mmio_map(g_mut_hndl, shim_vm->id, MV_SELF_ID) != MV_STATUS_SUCCESS) {
+                bferror("error while mapping pages");
+                goto undo_mmio_map;
+            }
+            mdl->num_entries = 0;
+        }
+        else {
+            ++mdl->num_entries;
+        }
+    }
+
+    platform_mutex_unlock(&shim_vm->mutex);
+
     return SHIM_SUCCESS;
+
+undo_mmio_map:
+    for (; i > 0; i -= HYPERVISOR_PAGE_SIZE) {
+        mdl->entries[mdl->num_entries].dst = gpa + i;
+        mdl->entries[mdl->num_entries].src = platform_virt_to_phys((void *)(addr + i));
+        mdl->entries[mdl->num_entries].bytes = HYPERVISOR_PAGE_SIZE;
+        mdl->entries[mdl->num_entries].flags = mv_flags;    // TODO: original flags
+
+        if (mdl->num_entries >= MV_MDL_MAX_ENTRIES) {
+            if (mv_vm_op_mmio_unmap(g_mut_hndl, shim_vm->id) != MV_STATUS_SUCCESS) {
+                bferror("error while unmapping previously mapped pages");
+            }
+            mdl->num_entries = 0;
+        }
+        else {
+            ++mdl->num_entries;
+        }
+    }
+
+    // platform_memunpin((void *)addr, size)
+
+unlock:
+    platform_mutex_unlock(&shim_vm->mutex);
+    return ret;
 }

--- a/shim/tests/src/platform.c
+++ b/shim/tests/src/platform.c
@@ -195,8 +195,8 @@ platform_memcpy(void *const pmut_dst, void const *const src, uint64_t const num)
 int64_t
 platform_mempin(void *const pmut_ptr, uint64_t const num)
 {
-    platform_expects(((uint64_t)pmut_ptr & 0x0000000000000FFF) == 0);
-    platform_expects((num & 0x0000000000000FFF) == 0);
+    platform_expects((((uint64_t)pmut_ptr) & 0x0000000000000FFFULL) == 0);
+    platform_expects((num & 0x0000000000000FFFULL) == 0);
 
     return 0;
 }
@@ -312,7 +312,8 @@ platform_mutex_init(platform_mutex *const pmut_mutex) NOEXCEPT
  * <!-- inputs/outputs -->
  *   @param pmut_mutex the mutex to destroy
  */
-void platform_mutex_destroy(platform_mutex *const pmut_mutex) NOEXCEPT
+void
+platform_mutex_destroy(platform_mutex *const pmut_mutex) NOEXCEPT
 {
     (void)pmut_mutex;
 }

--- a/shim/tests/src/platform.c
+++ b/shim/tests/src/platform.c
@@ -182,6 +182,27 @@ platform_memcpy(void *const pmut_dst, void const *const src, uint64_t const num)
 
 /**
  * <!-- description -->
+ *   @brief Pins the pages within a memory region starting at "pmut_ptr" and
+ *     continuing for "num" bytes. Once pinned, the memory is guaranteed to
+ *     never be paged out to disk.
+ *
+ * <!-- inputs/outputs -->
+ *   @param pmut_ptr a pointer to the memory to pin
+ *   @param num the number of bytes to pin.
+ *   @return This function returns 0 on success, otherwise
+ *     this function returns a non-0 value
+ */
+int64_t
+platform_mempin(void *const pmut_ptr, uint64_t const num)
+{
+    platform_expects(((uint64_t)pmut_ptr & 0x0000000000000FFF) == 0);
+    platform_expects((num & 0x0000000000000FFF) == 0);
+
+    return 0;
+}
+
+/**
+ * <!-- description -->
  *   @brief Copies "num" bytes from "src" to "pmut_dst". If "src" or "pmut_dst" are
  *     ((void *)0), returns FAILURE, otherwise returns 0. Note that this function can
  *     be used to copy memory from userspace via an IOCTL.

--- a/shim/tests/src/platform.c
+++ b/shim/tests/src/platform.c
@@ -285,6 +285,19 @@ platform_mutex_init(platform_mutex *const pmut_mutex) NOEXCEPT
 
 /**
  * <!-- description -->
+ *   @brief Destroys a mutex object. This must be called to free resources
+ *     allocated from platform_mutex_init.
+ *
+ * <!-- inputs/outputs -->
+ *   @param pmut_mutex the mutex to destroy
+ */
+void platform_mutex_destroy(platform_mutex *const pmut_mutex) NOEXCEPT
+{
+    (void)pmut_mutex;
+}
+
+/**
+ * <!-- description -->
  *   @brief Locks a mutex object. The mutex object must be initialized
  *     using platform_mutex_init before it is used.
  *

--- a/shim/tests/src/test_handle_vm_kvm_set_user_memory_region.cpp
+++ b/shim/tests/src/test_handle_vm_kvm_set_user_memory_region.cpp
@@ -24,7 +24,9 @@
 
 #include "../../include/handle_vm_kvm_set_user_memory_region.h"
 
+#include <helpers.hpp>
 #include <kvm_userspace_memory_region.h>
+#include <shim_vm_t.h>
 #include <types.h>
 
 #include <bsl/ut.hpp>
@@ -43,13 +45,21 @@ namespace shim
     [[nodiscard]] constexpr auto
     tests() noexcept -> bsl::exit_code
     {
-        bsl::ut_scenario{"description"} = []() noexcept {
+        bsl::ut_scenario{"valid user args"} = []() noexcept {
             bsl::ut_given{} = [&]() noexcept {
                 kvm_userspace_memory_region mut_args{};
+                mut_args.slot = 1;
+                mut_args.flags = 0;
+                mut_args.guest_phys_addr = 0x123456000ULL;
+                mut_args.memory_size = 0x1000;
+                mut_args.userspace_addr = 0x7FF123456000ULL;
+                shim_vm_t shim_vm{};
                 bsl::ut_when{} = [&]() noexcept {
                     bsl::ut_then{} = [&]() noexcept {
                         bsl::ut_check(
-                            SHIM_SUCCESS == handle_vm_kvm_set_user_memory_region(&mut_args));
+                            SHIM_SUCCESS ==
+                            // SHIM_SUCCESS);
+                            handle_vm_kvm_set_user_memory_region(&shim_vm, &mut_args));
                     };
                 };
             };


### PR DESCRIPTION
This patch set provides the following:
- Add support for KVM_SET_USER_MEMORY_REGION ioctl
  - Create a new memory region (mmio_map and creates a slot for bookeeping)
  - Delete an existing memory region (mmio_unmap and deletes an existing mem slot)
  - Update and move memory regions are currently missing
- Add platform_mempin allowing to pin memory and preventing it to be paged out
- Add platform_mutex_destroy and added its usage in vm_destroy
- Other minor fixes