### PR TITLE
fix KVM_GET_MSR_INDEX_LIST based on qemu interactions

### DIFF
--- a/shim/include/kvm_msr_list.h
+++ b/shim/include/kvm_msr_list.h
@@ -34,6 +34,8 @@ extern "C"
 {
 #endif
 
+#define MSR_LIST_MAX_INDICES 128
+
 #pragma pack(push, 1)
 
     /**
@@ -48,7 +50,7 @@ extern "C"
         uint32_t nmsrs;
 
         /** @brief array containing the indices of supported MSRs */
-        uint32_t *indices;
+        uint32_t indices[MSR_LIST_MAX_INDICES];
     };
 
 #pragma pack(pop)

--- a/shim/include/kvm_msr_list.hpp
+++ b/shim/include/kvm_msr_list.hpp
@@ -27,7 +27,11 @@
 #ifndef KVM_MSR_LIST_HPP
 #define KVM_MSR_LIST_HPP
 
-#include <bsl/cstdint.hpp>
+#include <bsl/array.hpp>
+#include <bsl/convert.hpp>
+#include <bsl/safe_integral.hpp>
+
+constexpr auto MSR_LIST_MAX_INDICES{128_u32};
 
 namespace shim
 {
@@ -45,7 +49,7 @@ namespace shim
         bsl::uint32 nmsrs;
 
         /** @brief array containing the indices of supported MSRs */
-        bsl::uint32 *indices;
+        bsl::array<bsl::uint32, MSR_LIST_MAX_INDICES.get()> indices;
     };
 }
 

--- a/shim/integration/kvm_get_msr_index_list.cpp
+++ b/shim/integration/kvm_get_msr_index_list.cpp
@@ -51,13 +51,11 @@ main() noexcept -> bsl::exit_code
 
     bsl::enable_color();
     integration::ioctl_t mut_system_ctl{shim::DEVICE_NAME};
-    bsl::array<bsl::uint32, bsl::uintmx(init_nmsrs.get())> mut_msr_indices{};
 
     // nmsrs is too big
     {
         mut_msr_list.nmsrs = HYPERVISOR_PAGE_SIZE.get();
         mut_msr_list.nmsrs++;
-        mut_msr_list.indices = mut_msr_indices.front_if();
 
         integration::verify(
             mut_system_ctl.write(shim::KVM_GET_MSR_INDEX_LIST, &mut_msr_list).is_neg());
@@ -65,7 +63,6 @@ main() noexcept -> bsl::exit_code
 
     {
         mut_msr_list.nmsrs = init_nmsrs.get();
-        mut_msr_list.indices = mut_msr_indices.front_if();
 
         integration::verify(
             mut_system_ctl.write(shim::KVM_GET_MSR_INDEX_LIST, &mut_msr_list).is_zero());
@@ -82,13 +79,13 @@ main() noexcept -> bsl::exit_code
         auto mut_nmsrs{bsl::to_idx(mut_msr_list.nmsrs)};
 
         for (bsl::safe_idx mut_i{}; mut_i < mut_nmsrs; ++mut_i) {
-            if (star_val == mut_msr_list.indices[mut_i.get()]) {
+            if (star_val == *mut_msr_list.indices.at_if(mut_i)) {
                 mut_found_star = true;
             }
-            else if (pat_val == mut_msr_list.indices[mut_i.get()]) {
+            else if (pat_val == *mut_msr_list.indices.at_if(mut_i)) {
                 mut_found_pat = true;
             }
-            else if (apic_base_val == mut_msr_list.indices[mut_i.get()]) {
+            else if (apic_base_val == *mut_msr_list.indices.at_if(mut_i)) {
                 mut_found_apic_base = true;
             }
         }

--- a/shim/linux/include/platform_interface/shim_platform_interface.h
+++ b/shim/linux/include/platform_interface/shim_platform_interface.h
@@ -78,6 +78,17 @@
 /** @brief defines the /dev name of the shim */
 #define SHIM_DEVICE_NAME "/dev/microv_shim"
 
+/**
+ * @brief Hack for defining ioctl commands that require structs
+ * with zero-length arrays. This is usually for ioctls that return
+ * a list. We will use arrays with defined length instead.
+ *
+ * It is just like _IOWR, except it takes a second type argument and
+ * subtracts its size from the size of the first type.
+ */
+#define _IOWR_LIST(type, nr, size, size_arr)                                                       \
+    _IOC(_IOC_READ | _IOC_WRITE, (type), (nr), sizeof(size) - sizeof(size_arr))
+
 /** @brief defines KVM's KVM_GET_API_VERSION IOCTL */
 #define KVM_GET_API_VERSION _IO(SHIMIO, 0x00)
 /** @brief defines KVM's KVM_CREATE_VM IOCTL */

--- a/shim/linux/include/platform_interface/shim_platform_interface.h
+++ b/shim/linux/include/platform_interface/shim_platform_interface.h
@@ -94,7 +94,8 @@
 /** @brief defines KVM's KVM_CREATE_VM IOCTL */
 #define KVM_CREATE_VM _IO(SHIMIO, 0x01)
 /** @brief defines KVM's KVM_GET_MSR_INDEX_LIST IOCTL */
-#define KVM_GET_MSR_INDEX_LIST _IOWR(SHIMIO, 0x02, struct kvm_msr_list)
+#define KVM_GET_MSR_INDEX_LIST                                                                     \
+    _IOWR_LIST(SHIMIO, 0x02, struct kvm_msr_list, uint32_t[MSR_LIST_MAX_INDICES])
 /** @brief defines KVM's KVM_GET_MSR_FEATURE_INDEX_LIST IOCTL */
 #define KVM_GET_MSR_FEATURE_INDEX_LIST _IOWR(SHIMIO, 0x0a, struct kvm_msr_list)
 /** @brief defines KVM's KVM_CHECK_EXTENSION IOCTL */

--- a/shim/linux/include/platform_interface/shim_platform_interface.hpp
+++ b/shim/linux/include/platform_interface/shim_platform_interface.hpp
@@ -79,6 +79,17 @@
 // #include <kvm_xen_hvm_config.hpp>
 // #include <kvm_xsave.hpp>
 
+/**
+ * @brief Hack for defining ioctl commands that require structs
+ * with zero-length arrays. This is usually for ioctls that return
+ * a list. We will use arrays with defined length instead.
+ *
+ * It is just like _IOWR, except it takes a second type argument and
+ * subtracts its size from the size of the first type.
+ */
+#define _IOWR_LIST(type, nr, size, size_arr)                                                       \
+    _IOC(_IOC_READ | _IOC_WRITE, (type), (nr), sizeof(size) - sizeof(size_arr))
+
 namespace shim
 {
     /// @brief magic number for KVM IOCTLs

--- a/shim/linux/include/platform_interface/shim_platform_interface.hpp
+++ b/shim/linux/include/platform_interface/shim_platform_interface.hpp
@@ -105,8 +105,8 @@ namespace shim
     /// @brief defines KVM's KVM_CREATE_VM IOCTL
     constexpr bsl::safe_umx KVM_CREATE_VM{static_cast<bsl::uintmx>(_IO(SHIMIO.get(), 0x01))};
     /// @brief defines KVM's KVM_GET_MSR_INDEX_LIST IOCTL
-    constexpr bsl::safe_umx KVM_GET_MSR_INDEX_LIST{
-        static_cast<bsl::uintmx>(_IOWR(SHIMIO.get(), 0x02, struct kvm_msr_list))};
+    constexpr bsl::safe_umx KVM_GET_MSR_INDEX_LIST{static_cast<bsl::uintmx>(
+        _IOWR_LIST(SHIMIO.get(), 0x02, struct kvm_msr_list, uint32_t[MSR_LIST_MAX_INDICES.get()]))};
     // /// @brief defines KVM's KVM_GET_MSR_FEATURE_INDEX_LIST IOCTL
     // constexpr bsl::safe_umx KVM_GET_MSR_FEATURE_INDEX_LIST{static_cast<bsl::uintmx>(_IOWR(SHIMIO.get(), 0x0a, struct kvm_msr_list))};
     /// @brief defines KVM's KVM_CHECK_EXTENSION IOCTL

--- a/shim/linux/include/types.h
+++ b/shim/linux/include/types.h
@@ -50,4 +50,9 @@
  */
 #define SHIM_INTERRUPTED ((int64_t)-EINTR)
 
+/**
+ * @brief Returned by a shim function when a provided data structure
+ *   is not large enough to hold the return data.
+ */
+#define SHIM_2BIG ((int64_t)-E2BIG)
 #endif

--- a/shim/linux/src/entry.c
+++ b/shim/linux/src/entry.c
@@ -233,54 +233,36 @@ dispatch_system_kvm_get_msr_index_list(
     struct kvm_msr_list __user *const user_args)
 {
     struct kvm_msr_list mut_args;
-    uint32_t __user *pmut_mut_user_indices;
     int64_t mut_ret;
-    uint64_t mut_alloc_size;
 
-    if (platform_copy_from_user(&mut_args, user_args, sizeof(mut_args))) {
+    if (platform_copy_from_user(
+            &mut_args,
+            user_args,
+            sizeof(mut_args) - sizeof(mut_args.indices))) {
         bferror("platform_copy_from_user failed");
         return -EINVAL;
     }
 
-    mut_alloc_size = mut_args.nmsrs * sizeof(*mut_args.indices);
-    if (mut_alloc_size > HYPERVISOR_PAGE_SIZE) {
-        bferror("requested nmsrs too big");
+    if (mut_args.nmsrs > MSR_LIST_MAX_INDICES) {
+        bferror("caller nmsrs exceeds MSR_LIST_MAX_INDICES");
         return -ENOMEM;
     }
 
-    pmut_mut_user_indices = mut_args.indices;
-    mut_args.indices = vzalloc(mut_alloc_size);
-
-    if (NULL == mut_args.indices) {
-        bferror("vzalloc failed");
-        return -ENOMEM;
-    }
-
-    mut_ret = -EINVAL;
     if (handle_system_kvm_get_msr_index_list(&mut_args)) {
         bferror("handle_system_kvm_get_msr_index_list failed");
-        goto out;
-    }
-
-    if (platform_copy_to_user(user_args, &mut_args, sizeof(mut_args.nmsrs))) {
-        bferror("platform_copy_to_user nmsrs failed");
-        goto out;
+        return -EINVAL;
     }
 
     if (platform_copy_to_user(
-            pmut_mut_user_indices,
-            mut_args.indices,
-            mut_args.nmsrs * sizeof(*mut_args.indices))) {
+            user_args,
+            &mut_args,
+            sizeof(mut_args.nmsrs) +
+                mut_args.nmsrs * sizeof(*mut_args.indices))) {
         bferror("platform_copy_to_user indices failed");
-        goto out;
+        return -EINVAL;
     }
 
-    mut_ret = 0;
-out:
-    if (mut_args.indices)
-        vfree(mut_args.indices);
-
-    return mut_ret;
+    return 0;
 }
 
 static long

--- a/shim/linux/src/entry.c
+++ b/shim/linux/src/entry.c
@@ -248,7 +248,17 @@ dispatch_system_kvm_get_msr_index_list(
         return -ENOMEM;
     }
 
-    if (handle_system_kvm_get_msr_index_list(&mut_args)) {
+    mut_ret = handle_system_kvm_get_msr_index_list(&mut_args);
+    if (SHIM_2BIG == mut_ret) {
+        if (platform_copy_to_user(
+                user_args, &mut_args, sizeof(mut_args.nmsrs))) {
+            bferror("platform_copy_to_user nmsrs failed");
+            return -EINVAL;
+        }
+
+        return -E2BIG;
+    }
+    else if (mut_ret) {
         bferror("handle_system_kvm_get_msr_index_list failed");
         return -EINVAL;
     }

--- a/shim/src/handle_system_kvm_get_msr_index_list.c
+++ b/shim/src/handle_system_kvm_get_msr_index_list.c
@@ -57,11 +57,6 @@ handle_system_kvm_get_msr_index_list(struct kvm_msr_list *const pmut_ioctl_args)
         return SHIM_FAILURE;
     }
 
-    if (NULL == pmut_ioctl_args->indices) {
-        bferror("indices not allocated");
-        return SHIM_FAILURE;
-    }
-
     platform_expects(MV_INVALID_HANDLE != g_mut_hndl);
 
     do {

--- a/shim/src/handle_system_kvm_get_msr_index_list.c
+++ b/shim/src/handle_system_kvm_get_msr_index_list.c
@@ -41,11 +41,14 @@
  *
  * <!-- inputs/outputs -->
  *   @param pmut_ioctl_args the arguments provided by userspace
- *   @return SHIM_SUCCESS on success, SHIM_FAILURE on failure.
+ *   @return SHIM_SUCCESS on success, SHIM_FAILURE on failure, and SHIM_2BIG when
+ *      the number of MSRs is greater than what was set in nmsrs. When SHIM_2BIG is
+ *      returned, the correct number of MSRs is set in the nmsrs field.
  */
 NODISCARD int64_t
 handle_system_kvm_get_msr_index_list(struct kvm_msr_list *const pmut_ioctl_args) NOEXCEPT
 {
+    int64_t mut_ret;
     int64_t mut_i;
     uint32_t mut_nmsrs = ((uint32_t)0);
 
@@ -73,18 +76,29 @@ handle_system_kvm_get_msr_index_list(struct kvm_msr_list *const pmut_ioctl_args)
             return SHIM_FAILURE;
         }
 
+        /**
+         * If the provided buffer is not large enough to fit all the MSRs, we still
+         * need to calculate the total number, and set the nmsrs field correctly.
+         */
         if (pmut_rdl->num_entries + ((uint64_t)mut_nmsrs) > ((uint64_t)pmut_ioctl_args->nmsrs)) {
-            bferror("number of MSRs is larger than kvm_msr_list indices");
-            return SHIM_FAILURE;
+            mut_nmsrs += pmut_rdl->num_entries;
         }
-
-        for (mut_i = ((int64_t)0); mut_i < ((int64_t)pmut_rdl->num_entries); ++mut_i) {
-            pmut_ioctl_args->indices[mut_nmsrs] = ((uint32_t)pmut_rdl->entries[mut_i].reg);
-            ++mut_nmsrs;
+        else {
+            for (mut_i = ((int64_t)0); mut_i < ((int64_t)pmut_rdl->num_entries); ++mut_i) {
+                pmut_ioctl_args->indices[mut_nmsrs] = ((uint32_t)pmut_rdl->entries[mut_i].reg);
+                ++mut_nmsrs;
+            }
         }
     } while (((uint64_t)0) != pmut_rdl->reg1);
 
+    if (mut_nmsrs > pmut_ioctl_args->nmsrs) {
+        mut_ret = SHIM_2BIG;
+    }
+    else {
+        mut_ret = SHIM_SUCCESS;
+    }
+
     pmut_ioctl_args->nmsrs = mut_nmsrs;
 
-    return SHIM_SUCCESS;
+    return mut_ret;
 }

--- a/shim/tests/include/types.h
+++ b/shim/tests/include/types.h
@@ -49,4 +49,10 @@
  */
 #define SHIM_INTERRUPTED ((int64_t)-2)
 
+/**
+ * @brief Returned by a shim function when a provided data structure
+ *   is not large enough to hold the return data.
+ */
+#define SHIM_2BIG ((int64_t)-3)
+
 #endif

--- a/shim/tests/src/test_handle_system_kvm_get_msr_index_list.cpp
+++ b/shim/tests/src/test_handle_system_kvm_get_msr_index_list.cpp
@@ -27,7 +27,6 @@
 #include <helpers.hpp>
 #include <kvm_msr_list.h>
 
-#include <bsl/array.hpp>
 #include <bsl/convert.hpp>
 #include <bsl/safe_integral.hpp>
 #include <bsl/ut.hpp>
@@ -36,7 +35,6 @@ namespace shim
 {
     constexpr auto VAL64{42_u64};
     constexpr auto INIT_NMSRS{0x10_u32};
-    bsl::array<bsl::uint32, bsl::uintmx(INIT_NMSRS.get())> g_mut_msr_indices{};
 
     /// <!-- description -->
     ///   @brief Used to execute the actual checks. We put the checks in this
@@ -57,7 +55,6 @@ namespace shim
             bsl::ut_given{} = [&]() noexcept {
                 kvm_msr_list mut_args{};
                 bsl::ut_when{} = [&]() noexcept {
-                    mut_args.indices = g_mut_msr_indices.front_if();
                     mut_args.nmsrs = INIT_NMSRS.get();
                     g_mut_val = bsl::safe_u64::magic_2().get();
                     bsl::ut_then{} = [&]() noexcept {
@@ -71,7 +68,6 @@ namespace shim
             bsl::ut_given{} = [&]() noexcept {
                 kvm_msr_list mut_args{};
                 bsl::ut_when{} = [&]() noexcept {
-                    mut_args.indices = g_mut_msr_indices.front_if();
                     mut_args.nmsrs = INIT_NMSRS.get();
                     g_mut_val = bsl::safe_u64::magic_2().get();
                     g_mut_mv_pp_op_msr_get_supported_list = MV_STATUS_FAILURE_SET_RDL_REG1;
@@ -86,25 +82,12 @@ namespace shim
             };
         };
 
-        bsl::ut_scenario{"indices not allocated"} = []() noexcept {
-            bsl::ut_given{} = [&]() noexcept {
-                kvm_msr_list mut_args{};
-                bsl::ut_when{} = [&]() noexcept {
-                    mut_args.nmsrs = INIT_NMSRS.get();
-                    bsl::ut_then{} = [&]() noexcept {
-                        bsl::ut_check(SHIM_FAILURE == handle(&mut_args));
-                    };
-                };
-            };
-        };
-
         bsl::ut_scenario{"hypervisor not detected"} = []() noexcept {
             bsl::ut_given{} = [&]() noexcept {
                 kvm_msr_list mut_args{};
                 bsl::ut_when{} = [&]() noexcept {
                     g_mut_hypervisor_detected = false;
                     mut_args.nmsrs = INIT_NMSRS.get();
-                    mut_args.indices = g_mut_msr_indices.front_if();
                     bsl::ut_then{} = [&]() noexcept {
                         bsl::ut_check(SHIM_FAILURE == handle(&mut_args));
                     };
@@ -119,9 +102,13 @@ namespace shim
             bsl::ut_given{} = [&]() noexcept {
                 kvm_msr_list mut_args{};
                 bsl::ut_when{} = [&]() noexcept {
+                    g_mut_val = VAL64.get();
                     mut_args.nmsrs = bsl::safe_u32::magic_0().get();
                     bsl::ut_then{} = [&]() noexcept {
                         bsl::ut_check(SHIM_FAILURE == handle(&mut_args));
+                    };
+                    bsl::ut_cleanup{} = [&]() noexcept {
+                        g_mut_val = {};
                     };
                 };
             };
@@ -133,7 +120,6 @@ namespace shim
                 bsl::ut_when{} = [&]() noexcept {
                     g_mut_mv_pp_op_msr_get_supported_list = MV_STATUS_FAILURE_CORRUPT_NUM_ENTRIES;
                     mut_args.nmsrs = INIT_NMSRS.get();
-                    mut_args.indices = g_mut_msr_indices.front_if();
                     bsl::ut_then{} = [&]() noexcept {
                         bsl::ut_check(SHIM_FAILURE == handle(&mut_args));
                     };
@@ -150,7 +136,6 @@ namespace shim
                 bsl::ut_when{} = [&]() noexcept {
                     g_mut_mv_pp_op_msr_get_supported_list = VAL64.get();
                     mut_args.nmsrs = INIT_NMSRS.get();
-                    mut_args.indices = g_mut_msr_indices.front_if();
                     bsl::ut_then{} = [&]() noexcept {
                         bsl::ut_check(SHIM_FAILURE == handle(&mut_args));
                     };
@@ -166,7 +151,6 @@ namespace shim
                 kvm_msr_list mut_args{};
                 bsl::ut_when{} = [&]() noexcept {
                     mut_args.nmsrs = INIT_NMSRS.get();
-                    mut_args.indices = g_mut_msr_indices.front_if();
                     g_mut_val = VAL64.get();
                     bsl::ut_then{} = [&]() noexcept {
                         bsl::ut_check(SHIM_FAILURE == handle(&mut_args));

--- a/shim/tests/src/test_handle_system_kvm_get_msr_index_list.cpp
+++ b/shim/tests/src/test_handle_system_kvm_get_msr_index_list.cpp
@@ -98,22 +98,6 @@ namespace shim
             };
         };
 
-        bsl::ut_scenario{"indices too small"} = []() noexcept {
-            bsl::ut_given{} = [&]() noexcept {
-                kvm_msr_list mut_args{};
-                bsl::ut_when{} = [&]() noexcept {
-                    g_mut_val = VAL64.get();
-                    mut_args.nmsrs = bsl::safe_u32::magic_0().get();
-                    bsl::ut_then{} = [&]() noexcept {
-                        bsl::ut_check(SHIM_FAILURE == handle(&mut_args));
-                    };
-                    bsl::ut_cleanup{} = [&]() noexcept {
-                        g_mut_val = {};
-                    };
-                };
-            };
-        };
-
         bsl::ut_scenario{"mv_pp_op_msr_get_supported_list corrupts num_entries"} = []() noexcept {
             bsl::ut_given{} = [&]() noexcept {
                 kvm_msr_list mut_args{};
@@ -153,7 +137,7 @@ namespace shim
                     mut_args.nmsrs = INIT_NMSRS.get();
                     g_mut_val = VAL64.get();
                     bsl::ut_then{} = [&]() noexcept {
-                        bsl::ut_check(SHIM_FAILURE == handle(&mut_args));
+                        bsl::ut_check(SHIM_2BIG == handle(&mut_args));
                     };
                     bsl::ut_cleanup{} = [&]() noexcept {
                         g_mut_val = {};


### PR DESCRIPTION
With these changes, qemu's execution advances past the KVM_GET_MSR_INDEX_LIST ioctl calls, as verified by the qemu_trace.sh script.