### PR TITLE
[mono] Fixes: early boot issue, TSC calibration issue, and Xue USB 3 DbC

### DIFF
--- a/.github/workflows/microv.yml
+++ b/.github/workflows/microv.yml
@@ -98,6 +98,7 @@ jobs:
         echo 'set(ENABLE_BUILD_EFI ON)' >> ../config.cmake
         echo 'set(XEN_REGISTER_BASED_ABI ON)' >> ../config.cmake
         echo 'set(XEN_READCONSOLE_ROOTVM ON)' >> ../config.cmake
+        echo 'set(USE_XUE ON)' >> ../config.cmake
         cmake ../microv/deps/hypervisor -DCONFIG=../config.cmake -DCMAKE_CXX_FLAGS="--verbose "
         make
       shell: bash

--- a/deps/hypervisor/bfdriver/src/platform/efi/entry.c
+++ b/deps/hypervisor/bfdriver/src/platform/efi/entry.c
@@ -260,7 +260,11 @@ void parse_cmdline(EFI_HANDLE image)
 
     for (i = 0; i < argc; i++) {
         if (!StrnCmp(opt_enable_xue, argv[i], StrLen(opt_enable_xue))) {
+#if(USE_XUE)
             Print(L"Enabling Xue USB Debugger\n");
+#else
+            Print(L"Error: Xue USB Debugger was disabled at compile time\n");
+#endif
             g_enable_xue = 1;
         }
 

--- a/deps/hypervisor/bfvmm/src/hve/arch/intel_x64/vcpu.cpp
+++ b/deps/hypervisor/bfvmm/src/hve/arch/intel_x64/vcpu.cpp
@@ -531,7 +531,6 @@ vcpu::dump(const char *str)
         bferror_subnhex(0, "cr2", ::intel_x64::cr2::get(), msg);
         bferror_subnhex(0, "cr3", guest_cr3::get(), msg);
         bferror_subnhex(0, "cr4", guest_cr4::get(), msg);
-        bferror_subnhex(0, "xcr0", ::intel_x64::xcr0::get(), msg);
 
         bferror_lnbr(0, msg);
         bferror_info(0, "addressing", msg);

--- a/deps/xue/include/xue.h
+++ b/deps/xue/include/xue.h
@@ -35,6 +35,7 @@
 #define XUE_XHC_DEV_WILDCAT_POINT 0x9CB1ULL
 #define XUE_XHC_DEV_SUNRISE_POINT 0x9D2FULL
 #define XUE_XHC_DEV_CANNON_POINT 0x9DEDULL
+#define XUE_XHC_DEV_COMET_LAKE 0x02EDULL
 
 /* DbC idVendor and idProduct */
 #define XUE_DBC_VENDOR 0x1D6B
@@ -67,6 +68,7 @@ static inline int known_xhc(uint32_t dev_ven)
     case (XUE_XHC_DEV_WILDCAT_POINT << 16) | XUE_XHC_VEN_INTEL:
     case (XUE_XHC_DEV_SUNRISE_POINT << 16) | XUE_XHC_VEN_INTEL:
     case (XUE_XHC_DEV_CANNON_POINT << 16) | XUE_XHC_VEN_INTEL:
+    case (XUE_XHC_DEV_COMET_LAKE << 16) | XUE_XHC_VEN_INTEL:
         return 1;
     default:
         return 0;

--- a/deps/xue/include/xue.h
+++ b/deps/xue/include/xue.h
@@ -36,6 +36,7 @@
 #define XUE_XHC_DEV_SUNRISE_POINT 0x9D2FULL
 #define XUE_XHC_DEV_CANNON_POINT 0x9DEDULL
 #define XUE_XHC_DEV_COMET_LAKE 0x02EDULL
+#define XUE_XHC_DEV_TIGER_LAKE 0xA0EDULL
 
 /* DbC idVendor and idProduct */
 #define XUE_DBC_VENDOR 0x1D6B
@@ -69,6 +70,7 @@ static inline int known_xhc(uint32_t dev_ven)
     case (XUE_XHC_DEV_SUNRISE_POINT << 16) | XUE_XHC_VEN_INTEL:
     case (XUE_XHC_DEV_CANNON_POINT << 16) | XUE_XHC_VEN_INTEL:
     case (XUE_XHC_DEV_COMET_LAKE << 16) | XUE_XHC_VEN_INTEL:
+    case (XUE_XHC_DEV_TIGER_LAKE << 16) | XUE_XHC_VEN_INTEL:
         return 1;
     default:
         return 0;

--- a/vmm/src/hve/arch/intel_x64/vmexit/yield.cpp
+++ b/vmm/src/hve/arch/intel_x64/vmexit/yield.cpp
@@ -33,6 +33,8 @@
 namespace microv::intel_x64 {
 
 //
+// 18.18 COUNTING CLOCKS
+//
 // The following formula for the TSC frequency (in MHz) is derived from the
 // description of the Max Non-Turbo Ratio field of the MSR_PLATFORM_INFO msr:
 //
@@ -114,6 +116,7 @@ static uint64_t bus_freq_khz()
     case 0x56:
     case 0x57:    // table 2-43
     case 0x85:
+    case 0x8C:
         return 100000;
 
     case 0x1A:    // table 2-14


### PR DESCRIPTION
This patch set provides the following changes:
- Fix early boot issue that would cause the system to hang during UEFI initialization on newer systems with 11th Gen CPU
- Fix TSC unable to be calibrated on newer systems with 11th Gen CPU
- TSC calibration should now be more accurate by leveraging CPUID.15H method when available
- Add support for newer USB 3 DbC xHCI controllers in Xue