### PR TITLE
mono: Add a build-efi-noeth artifact

### DIFF
--- a/.github/workflows/microv.yml
+++ b/.github/workflows/microv.yml
@@ -109,6 +109,38 @@ jobs:
         path: |
           build/prefixes/x86_64-efi-pe/bin/bareflank.efi
 
+  build-efi-noeth:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        path: microv
+
+    - name: Setup
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y python build-essential linux-headers-$(uname -r) nasm clang cmake libelf-dev
+      shell: bash
+
+    - name: Build EFI
+      run: |
+        mkdir build && cd build
+        cp ../microv/scripts/cmake/config/config.cmake ..
+        echo 'set(ENABLE_BUILD_USERSPACE OFF)' >> ../config.cmake
+        echo 'set(ENABLE_BUILD_VMM ON)' >> ../config.cmake
+        echo 'set(ENABLE_BUILD_EFI ON)' >> ../config.cmake
+        echo 'set(XEN_REGISTER_BASED_ABI ON)' >> ../config.cmake
+        echo 'set(ENABLE_NOETH_PT ON)' >> ../config.cmake
+        cmake ../microv/deps/hypervisor -DCONFIG=../config.cmake -DCMAKE_CXX_FLAGS="--verbose "
+        make
+      shell: bash
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: microv_efi_noeth
+        path: |
+          build/prefixes/x86_64-efi-pe/bin/bareflank.efi
+
   build-userpace:
     runs-on: windows-2019
     steps:

--- a/deps/hypervisor/bfsdk/include/printv.h
+++ b/deps/hypervisor/bfsdk/include/printv.h
@@ -1,0 +1,39 @@
+//
+// Copyright (C) 2019 Assured Information Security, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef MICROV_PRINTV_H
+#define MICROV_PRINTV_H
+
+#include <bfdebug.h>
+#include <stdio.h>
+
+#define printv(fmt, ...)                                                       \
+    printf("%s[%s%s0x%lx%s%s]%s " fmt,                                         \
+           bfcolor_cyan,                                                       \
+           bfcolor_end,                                                        \
+           bfcolor_yellow,                                                     \
+           thread_context_cpuid(),                                             \
+           bfcolor_end,                                                        \
+           bfcolor_cyan,                                                       \
+           bfcolor_end,                                                        \
+           ##__VA_ARGS__)
+
+#endif

--- a/deps/hypervisor/scripts/cmake/CMakeLists.txt
+++ b/deps/hypervisor/scripts/cmake/CMakeLists.txt
@@ -131,6 +131,7 @@ target_compile_definitions(bfroot INTERFACE
     $<${VMM_C_CXX}:__ELF__>
     $<$<BOOL:${USE_XUE}>:USE_XUE>
     $<$<BOOL:${XEN_REGISTER_BASED_ABI}>:XEN_REGISTER_BASED_ABI>
+    $<$<BOOL:${ENABLE_NOETH_PT}>:ENABLE_NOETH_PT>
 )
 target_include_directories(bfroot SYSTEM INTERFACE
     $<INSTALL_INTERFACE:$<${VMM_C_CXX}:${VMM_PREFIX_PATH}/include/c++/v1>>

--- a/scripts/cmake/config/default.cmake
+++ b/scripts/cmake/config/default.cmake
@@ -79,3 +79,10 @@ add_config(
     DEFAULT_VAL OFF
     DESCRIPTION "Allow to read the hypervisor debug output from the root vm"
 )
+
+add_config(
+    CONFIG_NAME ENABLE_NOETH_PT
+    CONFIG_TYPE BOOL
+    DEFAULT_VAL OFF
+    DESCRIPTION "Don't passthru ethernet devices, when passthru for network devices is enabled"
+)

--- a/uvctl/windows/service.cpp
+++ b/uvctl/windows/service.cpp
@@ -220,7 +220,21 @@ static void set_boot_entry() noexcept
     int res = system(
         "C:\\windows\\system32\\bcdedit.exe /set {bootmgr} path \\EFI\\Boot\\PreLoader.efi");
     if (res != 0) {
-        log_msg("bcdedit: failed to set microv boot manager entry: %d", res);
+        log_msg(
+            "bcdedit: failed to set MicroV boot manager entry: exit code %d",
+            res);
+    }
+    res = system(
+        "C:\\windows\\system32\\bcdedit.exe /set {fwbootmgr} displayorder {bootmgr}");
+    if (res != 0) {
+        log_msg("bcdedit: failed to set fwbootmgr displayorder: exit code %d",
+                res);
+    }
+    res = system(
+        "C:\\windows\\system32\\bcdedit.exe /set {fwbootmgr} bootsequence {bootmgr}");
+    if (res != 0) {
+        log_msg("bcdedit: failed to set fwbootmgr bootsequence: exit code %d",
+                res);
     }
 }
 

--- a/vmm/include/pci/cfg.h
+++ b/vmm/include/pci/cfg.h
@@ -24,6 +24,7 @@
 
 #include <bftypes.h>
 #include <arch/x64/portio.h>
+#include <printv.h>
 
 namespace microv {
 
@@ -173,6 +174,18 @@ inline bool pci_cfg_is_netdev(uint32_t reg2)
 {
     const auto cc = (reg2 & 0xFF00'0000) >> 24;
     return cc == pci_cc_network;
+}
+
+inline bool pci_cfg_is_netdev_eth(uint32_t reg2)
+{
+    const auto cc = (reg2 & 0xFF00'0000) >> 24;
+    const auto sc = (reg2 & 0x00FF'0000) >> 16;
+    const auto ret = cc == pci_cc_network && sc == 00;
+    printv("pci_cfg_is_netdev_eth: [class:subclass] [%02x:%02x] %s\n",
+           cc,
+           sc,
+           ret ? "eth" : "wireless");
+    return ret;
 }
 
 inline bool pci_cfg_is_host_bridge(uint32_t reg2)

--- a/vmm/include/pci/dev.h
+++ b/vmm/include/pci/dev.h
@@ -77,6 +77,11 @@ struct pci_dev {
         return pci_cfg_is_netdev(m_cfg_reg[2]);
     }
 
+    bool is_netdev_eth() const
+    {
+        return pci_cfg_is_netdev_eth(m_cfg_reg[2]);
+    }
+
     bool is_host_bridge() const
     {
         return pci_cfg_is_host_bridge(m_cfg_reg[2]);

--- a/vmm/src/pci.cpp
+++ b/vmm/src/pci.cpp
@@ -181,6 +181,13 @@ static void probe_bus(uint32_t b, struct pci_dev *bridge)
                     continue;
                 }
 
+                if (pdev->is_netdev_eth()) {
+                    printv(
+                        "pci: %s: passthrough disabled for ethernet device\n",
+                        pdev->bdf_str());
+                    continue;
+                }
+
                 bool misaligned_bar = false;
                 pdev->parse_bars();
 

--- a/vmm/src/pci.cpp
+++ b/vmm/src/pci.cpp
@@ -222,6 +222,9 @@ static void probe_bus(uint32_t b, struct pci_dev *bridge)
 
                 pci_passthru_list.push_back(pdev);
                 pci_passthru_busses.emplace(b);
+
+                printv("pci: %s: passthrough enabled for device\n",
+                       pdev->bdf_str());
             }
         }
     }

--- a/vmm/src/pci.cpp
+++ b/vmm/src/pci.cpp
@@ -181,12 +181,14 @@ static void probe_bus(uint32_t b, struct pci_dev *bridge)
                     continue;
                 }
 
+#ifdef ENABLE_NOETH_PT
                 if (pdev->is_netdev_eth()) {
                     printv(
                         "pci: %s: passthrough disabled for ethernet device\n",
                         pdev->bdf_str());
                     continue;
                 }
+#endif
 
                 bool misaligned_bar = false;
                 pdev->parse_bars();


### PR DESCRIPTION
Allows to not have an ethernet controller passthru when other network controllers are passthru, e.g. wireless ones.