### PR TITLE
Force UEFI boot order on service start and exit

### DIFF
--- a/.github/workflows/microv.yml
+++ b/.github/workflows/microv.yml
@@ -170,6 +170,7 @@ jobs:
         cp ..\microv\scripts\cmake\config\config.cmake ..
         Add-Content -Path ..\config.cmake -Value "set(ENABLE_BUILD_USERSPACE ON)"
         Add-Content -Path ..\config.cmake -Value "set(ENABLE_BUILD_VMM OFF)"
+        Add-Content -Path ..\config.cmake -Value "set(UVCTL_WINDOWS_SERVICE_FORCE_BOOTENTRY ON)"
         cmake ../microv/deps/hypervisor -DCONFIG=..\config.cmake -G "Visual Studio 16 2019" -A x64
         & msbuild /p:Configuration=Release /p:Platform=x64 /p:TargetVersion=Windows10 hypervisor.sln
       shell: pwsh

--- a/scripts/cmake/config/default.cmake
+++ b/scripts/cmake/config/default.cmake
@@ -86,3 +86,10 @@ add_config(
     DEFAULT_VAL OFF
     DESCRIPTION "Don't passthru ethernet devices, when passthru for network devices is enabled"
 )
+
+add_config(
+    CONFIG_NAME UVCTL_WINDOWS_SERVICE_FORCE_BOOTENTRY
+    CONFIG_TYPE BOOL
+    DEFAULT_VAL OFF
+    DESCRIPTION "Force setting MicroV UEFI boot entry"
+)

--- a/uvctl/CMakeLists.txt
+++ b/uvctl/CMakeLists.txt
@@ -47,6 +47,9 @@ target_sources(uvctl PRIVATE
     $<$<BOOL:${WIN32}>:${OS}/service.cpp>
     $<$<BOOL:${XEN_READCONSOLE_ROOTVM}>:${OS}/xen_hypercall.asm>
 )
-target_compile_definitions(uvctl PRIVATE $<$<BOOL:${XEN_READCONSOLE_ROOTVM}>:XEN_READCONSOLE_ROOTVM>)
+target_compile_definitions(uvctl PRIVATE
+    $<$<BOOL:${XEN_READCONSOLE_ROOTVM}>:XEN_READCONSOLE_ROOTVM>
+    $<$<BOOL:${UVCTL_WINDOWS_SERVICE_FORCE_BOOTENTRY}>:UVCTL_WINDOWS_SERVICE_FORCE_BOOTENTRY>
+)
 
 fini_project()

--- a/uvctl/main.cpp
+++ b/uvctl/main.cpp
@@ -379,6 +379,7 @@ int protected_main(const args_type &args)
 
             CloseHandle(xenbus_fd);
         }
+        service_post_tasks();
 #endif
     }
 

--- a/uvctl/windows/service.h
+++ b/uvctl/windows/service.h
@@ -24,5 +24,6 @@
 
 void service_start() noexcept;
 void service_wait_for_stop_signal() noexcept;
+void service_post_tasks() noexcept;
 
 #endif


### PR DESCRIPTION
Force UEFI boot order on service start and exit to ensure that the correct boot entry is always set to boot MicroV.
Add processor define to enable or disable the feature via cmake with `UVCTL_WINDOWS_SERVICE_FORCE_BOOTENTRY`.

By default this config is disabled.

Changes in CI:
- This feature is enabled in `build-userpace` job
- This feature is not enabled in `build-userpace-debug` job