### PR TITLE
Set CR4[18] OSXSAVE in cr4_guest_host_mask

### DIFF
--- a/deps/hypervisor/bfvmm/src/hve/arch/intel_x64/vcpu.cpp
+++ b/deps/hypervisor/bfvmm/src/hve/arch/intel_x64/vcpu.cpp
@@ -162,6 +162,7 @@ vcpu::vcpu(
     m_microcode_handler{this},
     m_vpid_handler{this}
 {
+    using namespace ::intel_x64::cr4::osxsave;
     using namespace vmcs_n;
     bfn::call_once(g_once_flag, setup);
 
@@ -197,7 +198,7 @@ vcpu::vcpu(
     m_vpid_handler.enable();
     m_nmi_handler.enable_exiting();
     m_control_register_handler.enable_wrcr0_exiting(0);
-    m_control_register_handler.enable_wrcr4_exiting(0);
+    m_control_register_handler.enable_wrcr4_exiting(::intel_x64::cr4::osxsave::mask);
 }
 
 //==============================================================================


### PR DESCRIPTION
    Set CR4[18] OSXSAVE in cr4_guest_host_mask
    
    During boot Windows 11 as a guest VM was
    faulting on XSETBV instruction because
    CR4[18] OSXSAVE was not set. (XSETBEV is
    undefined if CR4[18] OSXSAVE is not set.)
    
    This patch sets cr4_guest_host_mask[18]
    causing the the corresponding cr4 shadow
    register to virtualize the state of
    CR4[18].  This results in a more robust
    CR4 implementation and removes the chance
    of CR4[18] OSXSAVE corruption.
